### PR TITLE
[Add] migration to rename cols

### DIFF
--- a/db/migrations/V0002__rename_recommendation_cols.sql
+++ b/db/migrations/V0002__rename_recommendation_cols.sql
@@ -13,5 +13,3 @@ CREATE TABLE recommendation (
   updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   UNIQUE (model_id, source_entity_id, recommended_article_id)
 );
-
-CREATE INDEX idx_source_entity_id_model_id ON recommendation (source_entity_id, model_id);


### PR DESCRIPTION
## description 
renames confusing columns external_id and article_id to clarify which refers to the source entity (the article or user being recommended for) and which refers to the recommended article. 

## testing 
✅ applied migration to dev db 
```
Flyway Community Edition 7.2.0 by Redgate
Database: jdbc:postgresql://dd1xozqdljjrl8e.clwbfgtlfi6m.us-east-1.rds.amazonaws.com:5432/DevArticleRecDB (PostgreSQL 12.4)
Successfully validated 2 migrations (execution time 00:00.072s)
Current version of schema "public": 0001
Migrating schema "public" to version "0002 - rename recommendation cols"
Successfully applied 1 migration to schema "public" (execution time 00:00.510s)
```