### PR TITLE
[Add] catch peewee integrity error for duplicate creates

### DIFF
--- a/job/helpers.py
+++ b/job/helpers.py
@@ -85,7 +85,7 @@ def find_or_create_articles(site: Site, paths: List[int]) -> (int, int):
             scrape_and_create_article(site=site, path=path, external_id=external_id)
             found_external_ids.add(external_id)
             total_scraped += 1
-        except BadArticleFormatError, IntegrityError:
+        except (BadArticleFormatError, IntegrityError):
             logging.exception(f"Skipping article with external_id: {external_id}")
             scraping_errors += 1
     articles = get_articles_by_external_ids(external_ids)


### PR DESCRIPTION
fix small error we're seeing after merging https://github.com/LocalAtBrown/article-rec-training-job/pull/29 

```
peewee.IntegrityError: duplicate key value violates unique constraint "uq_external_id"
```