### PR TITLE
[Fix] missing "tmp" directory error in prod

### DIFF
--- a/lib/bucket.py
+++ b/lib/bucket.py
@@ -1,6 +1,7 @@
 import boto3
 import logging
 import numpy as np
+import os
 import pandas as pd
 
 from functools import wraps
@@ -12,6 +13,7 @@ from lib.config import ROOT_DIR
 RESOURCE = boto3.resource("s3")
 CLIENT = boto3.client("s3")
 ARTIFACT_BUCKET = 'lnl-monitoring-artifacts'
+os.makedirs(f"{ROOT_DIR}/tmp", exist_ok=True)
 
 
 def list_objects(bucket: str, prefix: str) -> List[str]:


### PR DESCRIPTION
This error showed up in prod but not in dev because `cdk deploy` copies the whole local file structure when deploying.

Need to be careful to clean up untracked files when deploying to ensure consistency between dev and prod deployments :/
![image](https://user-images.githubusercontent.com/20174907/120010575-4bfb3800-bfab-11eb-9f67-58cd80eb0ee4.png)

This directory creation call should fix it.