### PR TITLE
[Fix] error caused by NaN URLs in Snowplow

### DIFF
--- a/job/steps/preprocess.py
+++ b/job/steps/preprocess.py
@@ -14,7 +14,8 @@ from lib.bucket import save_outputs
 
 
 def filter_emailnewsletter(data_df: pd.DataFrame) -> pd.DataFrame:
-    filtered_df = data_df[data_df.landing_page_path.apply(lambda x: 'emailnewsletter' not in x)]
+    filtered_df = data_df[data_df.landing_page_path.notna()]
+    filtered_df = filtered_df[filtered_df.landing_page_path.apply(lambda x: 'emailnewsletter' not in x)]
     return filtered_df
 
 


### PR DESCRIPTION
We're starting to get some NaN `page_urlpath` events in Snowplow. Not sure why, @E-Rick maybe you can investigate? Here's an example event:

![image](https://user-images.githubusercontent.com/20174907/120709329-b704ad00-c48a-11eb-9884-f8417a5d8d4a.png)

It's causing this error:

![image](https://user-images.githubusercontent.com/20174907/120708584-c0d9e080-c489-11eb-83e2-e7361139876f.png)

I added a line to filter out NaN URLs to fix this.