### PR TITLE
[Add] experiment_dt param to fetch_data

### DIFF
--- a/job/job.py
+++ b/job/job.py
@@ -25,7 +25,8 @@ def run():
     try:
         model_id = create_model(type=Type.ARTICLE.value)
         logging.info(f"Created model with id {model_id}")
-        data_df = fetch_data.fetch_data()
+        EXPERIMENT_DT = datetime.datetime.now()
+        data_df = fetch_data.fetch_data(EXPERIMENT_DT)
         filtered_df = preprocess.filter_emailnewsletter(data_df)
         filtered_df = preprocess.filter_flyby_users(filtered_df)
 
@@ -41,7 +42,7 @@ def run():
         EXPERIMENT_DATE = datetime.date.today()
         # Hyperparameters derived using optimize_ga_pipeline.ipynb notebook in google-analytics-exploration
         formatted_df = preprocess.model_preprocessing(
-            prepared_df, date_list=[EXPERIMENT_DATE], half_life=59.631698
+            prepared_df, date_list=[EXPERIMENT_DT.date()], half_life=59.631698
         )
         model = train_model.train_model(
             X=formatted_df, reg=2.319952, n_components=130, epochs=2

--- a/job/steps/fetch_data.py
+++ b/job/steps/fetch_data.py
@@ -96,12 +96,13 @@ def retry_s3_select(
 
 
 def fetch_data(
+    experiment_dt: datetime.datetime,
     days: int = DAYS_OF_DATA,
     fields: List[str] = FIELDS,
     transformer: Callable = transform_raw_data,
 ) -> pd.DataFrame:
     start_ts = time.time()
-    dt = datetime.datetime.now()
+    dt = experiment_dt
     data_dfs = []
 
     for _ in range(days):


### PR DESCRIPTION
## description 
allows ability to specify experiment date to fetch_data call. this let's us:
1) pull correct training data when experiment_date is used
2) more easily debug potential issues with fetch_data 

## local testing
1. run the job: `kar build && kar run`
2. confirm model trains successfully, should see logging similar to below at end of job:
```
INFO:root:Skipping metric write for name:model_training_time value:0.5412685871124268
INFO:root:Uploading model_item_vectors.npy to s3...
INFO:root:Successfully uploaded model_item_vectors.npy to s3
INFO:root:Successfully trained model on 795 inputs.
INFO:root:Uploading vector_similarities.npy to s3...
INFO:root:Successfully uploaded vector_similarities.npy to s3
INFO:root:Uploading vector_weights.npy to s3...
INFO:root:Successfully uploaded vector_weights.npy to s3
INFO:root:Uploading vector_orders.npy to s3...
INFO:root:Successfully uploaded vector_orders.npy to s3
INFO:root:Skipping metric write for name:rec_creation_time value:10.780191898345947
INFO:root:Skipping metric write for name:rec_creation_total value:182
INFO:root:Successfully updated current article model: 914
INFO:root:found 637 models to delete, deleting a max of 10...
INFO:root:deleted model_ids: [212, 213, 214, 215, 216, 217, 218, 210, 253, 220]
INFO:root:Skipping metric write for name:job_time value:91.76748752593994
```