### PR TITLE
Resolve redirect error

### DIFF
--- a/job/steps/scrape_metadata.py
+++ b/job/steps/scrape_metadata.py
@@ -14,7 +14,7 @@ from db.helpers import (
     create_rec,
 )
 from sites.sites import Site
-from sites.helpers import BadArticleFormatError
+from sites.helpers import ArticleScrapingError
 from lib.bucket import save_outputs
 from lib.metrics import write_metric, Unit
 
@@ -22,7 +22,7 @@ from lib.metrics import write_metric, Unit
 BACKFILL_ISO_DATE = "2021-03-05"
 
 
-@save_outputs('article_df.csv')
+@save_outputs("article_df.csv")
 def scrape_metadata(site: Site, paths: List[int]) -> pd.DataFrame:
     """
     Find articles on news website from list of paths, then associate with corresponding identifiers.
@@ -46,7 +46,7 @@ def scrape_metadata(site: Site, paths: List[int]) -> pd.DataFrame:
         try:
             scrape_and_update_article(site=site, article=article)
             total_scraped += 1
-        except BadArticleFormatError:
+        except ArticleScrapingError:
             logging.exception(
                 f"Skipping article with external_id: {article.external_id}"
             )
@@ -58,7 +58,7 @@ def scrape_metadata(site: Site, paths: List[int]) -> pd.DataFrame:
             scrape_and_create_article(site=site, path=path, external_id=external_id)
             found_external_ids.add(external_id)
             total_scraped += 1
-        except (BadArticleFormatError, IntegrityError):
+        except (ArticleScrapingError, IntegrityError):
             logging.exception(f"Skipping article with external_id: {external_id}")
             scraping_errors += 1
     articles = get_articles_by_external_ids(external_ids)

--- a/sites/helpers.py
+++ b/sites/helpers.py
@@ -3,7 +3,7 @@ import requests as req
 from retrying import retry
 
 
-class BadArticleFormatError(Exception):
+class ArticleScrapingError(Exception):
     pass
 
 


### PR DESCRIPTION
## description 
catch errors fetching articles, for ex when we receive a malformed url path from google analytics

resolves the issue described in [this story](https://www.notion.so/training-job-TooManyRedirects-error-causes-job-to-fail-regularly-e3d6868db7b445b9a057c2a8b757d4b3)

## local testing
1. build container and enter shell: `kar build && kar run bash`
2. open python repl: `python`
3. run below code:
```
from job.steps import (
    scrape_metadata,
)
from sites.sites import Sites

bad_path = "/article/205866/washingtoncitypaper.com/"
article_df = scrape_metadata.scrape_metadata(Sites.WCP, [bad_path])
```
4. confirm that logs contain the line `ERROR:root:Skipping article with external_id: 205866`. we expect the exception to be logged, but this line means the job will proceed.
```
ERROR:root:Error fetching article: https://washingtoncitypaper.com/article/205866/washingtoncitypaper.com/
Traceback (most recent call last):
  File "/app/sites/washington_city_paper.py", line 49, in scrape_article_metadata
    page = safe_get(url)
  File "/usr/local/lib/python3.8/site-packages/retrying.py", line 49, in wrapped_f
    return Retrying(*dargs, **dkw).call(f, *args, **kw)
  File "/usr/local/lib/python3.8/site-packages/retrying.py", line 212, in call
    raise attempt.get()
  File "/usr/local/lib/python3.8/site-packages/retrying.py", line 247, in get
    six.reraise(self.value[0], self.value[1], self.value[2])
  File "/usr/local/lib/python3.8/site-packages/six.py", line 703, in reraise
    raise value
  File "/usr/local/lib/python3.8/site-packages/retrying.py", line 200, in call
    attempt = Attempt(fn(*args, **kwargs), attempt_number, False)
  File "/app/sites/helpers.py", line 13, in safe_get
    page = req.get(url, timeout=TIMEOUT_SECONDS)
  File "/usr/local/lib/python3.8/site-packages/requests/api.py", line 76, in get
    return request('get', url, params=params, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/requests/api.py", line 61, in request
    return session.request(method=method, url=url, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/requests/sessions.py", line 542, in request
    resp = self.send(prep, **send_kwargs)
  File "/usr/local/lib/python3.8/site-packages/requests/sessions.py", line 677, in send
    history = [resp for resp in gen]
  File "/usr/local/lib/python3.8/site-packages/requests/sessions.py", line 677, in <listcomp>
    history = [resp for resp in gen]
  File "/usr/local/lib/python3.8/site-packages/requests/sessions.py", line 166, in resolve_redirects
    raise TooManyRedirects('Exceeded {} redirects.'.format(self.max_redirects), response=resp)
requests.exceptions.TooManyRedirects: Exceeded 30 redirects.
ERROR:root:Skipping article with external_id: 205866
Traceback (most recent call last):
  File "/app/sites/washington_city_paper.py", line 49, in scrape_article_metadata
    page = safe_get(url)
  File "/usr/local/lib/python3.8/site-packages/retrying.py", line 49, in wrapped_f
    return Retrying(*dargs, **dkw).call(f, *args, **kw)
  File "/usr/local/lib/python3.8/site-packages/retrying.py", line 212, in call
    raise attempt.get()
  File "/usr/local/lib/python3.8/site-packages/retrying.py", line 247, in get
    six.reraise(self.value[0], self.value[1], self.value[2])
  File "/usr/local/lib/python3.8/site-packages/six.py", line 703, in reraise
    raise value
  File "/usr/local/lib/python3.8/site-packages/retrying.py", line 200, in call
    attempt = Attempt(fn(*args, **kwargs), attempt_number, False)
  File "/app/sites/helpers.py", line 13, in safe_get
    page = req.get(url, timeout=TIMEOUT_SECONDS)
  File "/usr/local/lib/python3.8/site-packages/requests/api.py", line 76, in get
    return request('get', url, params=params, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/requests/api.py", line 61, in request
    return session.request(method=method, url=url, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/requests/sessions.py", line 542, in request
    resp = self.send(prep, **send_kwargs)
  File "/usr/local/lib/python3.8/site-packages/requests/sessions.py", line 677, in send
    history = [resp for resp in gen]
  File "/usr/local/lib/python3.8/site-packages/requests/sessions.py", line 677, in <listcomp>
    history = [resp for resp in gen]
  File "/usr/local/lib/python3.8/site-packages/requests/sessions.py", line 166, in resolve_redirects
    raise TooManyRedirects('Exceeded {} redirects.'.format(self.max_redirects), response=resp)
requests.exceptions.TooManyRedirects: Exceeded 30 redirects.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/app/job/steps/scrape_metadata.py", line 58, in scrape_metadata
    scrape_and_create_article(site=site, path=path, external_id=external_id)
  File "/app/job/steps/scrape_metadata.py", line 107, in scrape_and_create_article
    metadata = scrape_article_metadata(site, path)
  File "/app/job/steps/scrape_metadata.py", line 114, in scrape_article_metadata
    return site.scrape_article_metadata(path)
  File "/app/sites/washington_city_paper.py", line 53, in scrape_article_metadata
    raise ArticleScrapingError(msg) from e
sites.helpers.ArticleScrapingError: Error fetching article: https://washingtoncitypaper.com/article/205866/washingtoncitypaper.com/
```