### PR TITLE
[Change] keep processing data if one day fails

### DIFF
--- a/job/steps/fetch_data.py
+++ b/job/steps/fetch_data.py
@@ -129,7 +129,7 @@ def fetch_data(
                     logging.exception(
                         f"Unexpected format. Can't transform data for {prefix}"
                     )
-                    break
+                    continue
 
                 if df.size:
                     data_dfs.append(df)


### PR DESCRIPTION
## description
i realized i introduced a small bug in https://github.com/LocalAtBrown/article-rec-training-job/pull/52

by breaking out of the loop if a day of data could not be transformed, rather than continuing, ie: 

```
>>> for i in range(10):
...   print(i)
...   if i == 5:
...     break
... 
0
1
2
3
4
5
```
vs 
```
>>> for i in range(10):
...   print(i)
...   if i == 5:
...     continue
... 
0
1
2
3
4
5
6
7
8
9
```
```