### PR TITLE
Parallelize scraping stage

### DIFF
--- a/job/steps/scrape_metadata.py
+++ b/job/steps/scrape_metadata.py
@@ -123,7 +123,7 @@ def scrape_articles(
     """
     futures_list = []
     results = []
-    with ThreadPoolExecutor(max_workers=13) as executor:
+    with ThreadPoolExecutor() as executor:
         for article in articles:
             future = executor.submit(scrape_article, site, article=article)
             futures_list.append(future)


### PR DESCRIPTION
Use thread pools and Peewee's bulk execution API to improve the perf on the scraping stage.

I benchmarked it on 150 articles (which is about how many there were to refresh on dev after 15 minutes from the last run) and saw an improvement from 90 to 30 seconds. Not bad!

Tested with `kar test`