### PR TITLE
[Add] default headers to all requests

### DIFF
--- a/sites/helpers.py
+++ b/sites/helpers.py
@@ -1,3 +1,4 @@
+from typing import Dict
 import requests as req
 
 from retrying import retry
@@ -8,7 +9,10 @@ class ArticleScrapingError(Exception):
 
 
 @retry(stop_max_attempt_number=3, wait_exponential_multiplier=1000)
-def safe_get(url: str, headers=None) -> str:
+def safe_get(url: str, headers: Dict[str, str] = None) -> str:
     TIMEOUT_SECONDS = 30
-    page = req.get(url, timeout=TIMEOUT_SECONDS, headers=headers)
+    default_headers = {"User-Agent": "article-rec-training-job/1.0.0"}
+    if headers:
+        default_headers.update(headers)
+    page = req.get(url, timeout=TIMEOUT_SECONDS, headers=default_headers)
     return page

--- a/sites/texas_tribune.py
+++ b/sites/texas_tribune.py
@@ -14,7 +14,6 @@ import time
 DOMAIN = "www.texastribune.org"
 NAME = "texas-tribune"
 FIELDS = ["collector_tstamp", "page_urlpath", "domain_userid"]
-HEADERS = {"User-Agent": "article-rec-training-job/1.0.0"}
 
 
 def transform_data_google_tag_manager(df: pd.DataFrame) -> pd.DataFrame:
@@ -52,7 +51,7 @@ def extract_external_id(path: str) -> str:
     article_url = f"https://{DOMAIN}{path}"
 
     try:
-        page = safe_get(article_url, HEADERS)
+        page = safe_get(article_url)
         time.sleep(10)
     except Exception as e:
         msg = f"Error fetching article url: {article_url}"
@@ -124,7 +123,7 @@ def validate_article(
     logging.info(f"Validating article url: {api_url}")
 
     try:
-        res = safe_get(api_url, HEADERS)
+        res = safe_get(api_url)
         time.sleep(10)
     except Exception as e:
         msg = f"Error fetching article url: {api_url}"


### PR DESCRIPTION
## description 
fix error scraping wcp articles (newspack/wordpress made a change around 10 days ago that throws a 421 on any request that doesn't include the expected headers) 

ty Sylvan for help identifying this fix 

## tests
- [x] metadata scrape runs locally
- [x] tests pass 
- [x] metadata scrape runs on dev ([logs](https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/DevArticleRecTrainingJobLogGroup/log-events/DevWashingtonCityPaperArticleRecTrainingJob$252FDevWashingtonCityPaperArticleRecTrainingJobTaskContainer$252F9edaa1e0d219431a90e397bb65eafb09))

## logs
no title scraping errors ✅ 
```
INFO:root:Scraping metadata from url: https://washingtoncitypaper.com/article/540721/
INFO:root:Validating article url: https://washingtoncitypaper.com/article/538416
INFO:root:Scraping metadata from url: https://washingtoncitypaper.com/article/200296/
INFO:root:Validating article url: https://washingtoncitypaper.com/article/538412
INFO:root:Scraping metadata from url: https://washingtoncitypaper.com/article/541284/
INFO:root:Validating article url: https://washingtoncitypaper.com/article/191363
WARNING:root:Error while validating article 537883: 'Article has exclude tag'
INFO:root:Validating article url: https://washingtoncitypaper.com/article/539893
WARNING:root:Error while validating article 532819: 'Article has exclude tag'
```