### PR TITLE
Only fetch one day of data at a time

### DIFF
--- a/job/job.py
+++ b/job/job.py
@@ -66,7 +66,7 @@ def run():
         EXPERIMENT_DT = datetime.now().date()
 
         ## Step 1: Fetch fresh data, hydrate it, and upload it to the warehouse
-        data_df, article_df = fetch_and_upload_data(site, EXPERIMENT_DT)
+        fetch_and_upload_data(site, EXPERIMENT_DT, days=1)
 
         ## Step 2: Train models by pulling data from the warehouse and uploading
         ## new recommendation objects


### PR DESCRIPTION
Now that we are using the warehouse for both default recommendations and the Spotlight model, we only need to pull one day of data from S3 to update the warehouse