### PR TITLE
Better rate limit

### DIFF
--- a/job/steps/scrape_metadata.py
+++ b/job/steps/scrape_metadata.py
@@ -108,8 +108,6 @@ def update_path_cache(
 
 
 def extract_external_id(site: Site, path: str) -> str:
-    if site.scrape_config["requests_per_second"]:
-        time.sleep(1 / site.scrape_config["requests_per_second"])
     return site.extract_external_id(path)
 
 
@@ -163,8 +161,6 @@ def scrape_article(
             setattr(article, key, value)
 
     article.site = site.name
-    if site.scrape_config["requests_per_second"]:
-        time.sleep(1 / site.scrape_config["requests_per_second"])
     return article
 
 

--- a/sites/helpers.py
+++ b/sites/helpers.py
@@ -1,10 +1,12 @@
 from enum import Enum
 from datetime import datetime
+import time
 
 from typing import Dict, Optional
 import requests as req
 import pandas as pd
 from retrying import retry
+from sites.site import Site
 
 
 GOOGLE_TAG_MANAGER_RAW_FIELDS = {
@@ -70,11 +72,13 @@ class ArticleScrapingError(Exception):
 
 @retry(stop_max_attempt_number=3, wait_exponential_multiplier=1000)
 def safe_get(
-    url: str, headers: Dict[str, str] = None, params: Optional[Dict] = None
+    site: Site, url: str, headers: Dict[str, str] = None, params: Optional[Dict] = None
 ) -> str:
     TIMEOUT_SECONDS = 30
     default_headers = {"User-Agent": "article-rec-training-job/1.0.0"}
     if headers:
         default_headers.update(headers)
     page = req.get(url, timeout=TIMEOUT_SECONDS, params=params, headers=default_headers)
+    if site.scrape_config.get("requests_per_second"):
+        time.sleep(1 / site.scrape_config["requests_per_second"])
     return page

--- a/sites/philadelphia_inquirer.py
+++ b/sites/philadelphia_inquirer.py
@@ -65,8 +65,6 @@ def bulk_fetch(
     metadata = [
         parse_article_metadata(a, a["_id"]) for a in json_res["content_elements"]
     ]
-    # TODO replace with 1 / config-specified rps after it's merged
-    time.sleep(0.25)
     return metadata
 
 

--- a/sites/texas_tribune.py
+++ b/sites/texas_tribune.py
@@ -94,7 +94,6 @@ def extract_external_id(path: str) -> str:
     article_url = f"https://{DOMAIN}{path}"
     try:
         page = safe_get(article_url)
-        time.sleep(1)
     except Exception as e:
         raise ArticleScrapingError(
             ScrapeFailure.FETCH_ERROR,
@@ -186,7 +185,6 @@ def fetch_article(
 
     try:
         res = safe_get(api_url)
-        time.sleep(1)
     except Exception as e:
         msg = f"Error fetching article url: {api_url}"
         raise ArticleScrapingError(


### PR DESCRIPTION
I forgot to remove the time.sleep's that we had lying around previously: removed these

Also, I moved the wait logic to the safe_get method, so that we guarantee maintaining rate limit for actual requests but don't bother waiting for requests that don't actually hit the API (eg, for texas tribune sometimes we skip the path without hitting the API)