### PR TITLE
Catch duplicate paths within the same batch

### DIFF
--- a/job/steps/scrape_metadata.py
+++ b/job/steps/scrape_metadata.py
@@ -220,6 +220,7 @@ def new_articles_from_paths(
             )
         else:
             new_articles.append(Article(external_id=ext_id, path=path))
+            existing_external_ids.add(ext_id)
 
     return new_articles, errors
 


### PR DESCRIPTION
When craeting new articles, add each external ID to the set of `existing_external_ids` so that we don't create duplicate articles in the rare-ish case that multiple paths map to the same external ID