### PR TITLE
filter out all wire and test articles for pi

### DIFF
--- a/sites/philadelphia_inquirer.py
+++ b/sites/philadelphia_inquirer.py
@@ -69,7 +69,7 @@ def bulk_fetch(
     return metadata
 
 
-NON_ARTICLE_PREFIXES = ["/author"]
+INVALID_PREFIXES = ["/author", "/wires", "/zzz-systest"]
 
 
 def extract_external_id(path: str) -> Optional[str]:
@@ -85,13 +85,13 @@ def extract_external_id(path: str) -> Optional[str]:
         "included_fields": "_id,source,taxonomy",
     }
 
-    for prefix in NON_ARTICLE_PREFIXES:
+    for prefix in INVALID_PREFIXES:
         if path.startswith(prefix):
             raise ArticleScrapingError(
-                ScrapeFailure.NO_EXTERNAL_ID,
+                ScrapeFailure.FAILED_SITE_VALIDATION,
                 path,
                 external_id=None,
-                msg="Skipping non-article path",
+                msg="Skipping path with invalid prefix",
             )
 
     try:


### PR DESCRIPTION
## description
adds filtering specified by @todgillespie to exclude wire and test articles 

see slack [thread](https://browninstitute.slack.com/archives/C02FD5HJSL9/p1645122300674309) for more

## testing 
✅ test article excluded
```
>>> path = '/zzz-systest/visuals-assignment-20181201.html'
>>> extract_external_id(path)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/app/sites/philadelphia_inquirer.py", line 121, in extract_external_id
    raise ArticleScrapingError(
sites.helpers.ArticleScrapingError: (<ScrapeFailure.FAILED_SITE_VALIDATION: 'failed_site_validation'>, '/zzz-systest/visuals-assignment-20181201.html', '2A2G72L6TJCKPH2RRKFKW6PRTA', 'Test article')
```
✅ wire article excluded
```
>>> path = '/wires/ap/top-german-court-rejects-injunction-against-vaccine-mandate-20220211.html'
>>> extract_external_id(path)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/app/sites/philadelphia_inquirer.py", line 113, in extract_external_id
    raise ArticleScrapingError(
sites.helpers.ArticleScrapingError: (<ScrapeFailure.FAILED_SITE_VALIDATION: 'failed_site_validation'>, '/wires/ap/top-german-court-rejects-injunction-against-vaccine-mandate-20220211.html', 'K4LGS3UN25B3DJKRB7QLCKFUCE', 'Not in-house article')
```
✅ good article not excluded
```
>>> path = '/health/mazzoni-center-sultan-shakir-new-ceo-20220222.html'
>>> extract_external_id(path)
'HL5IZD5KGBBGNFIAM4OHNJPG3U'
```
✅ job runs locally
```
~/lnl/article-rec-training-job [philly-inquirer-article-filtering●] kar run
/app/job/steps/trainer.py:22: FutureWarning: The pandas.datetime class is deprecated and will be removed from pandas in a future version. Import from datetime module instead.
  experiment_time:pd.datetime,
INFO:root:Running job...
INFO:root:Using site washington-city-paper
INFO:root:aws s3 sync s3://lnl-snowplow-washington-city-paper/enriched/good/2022/02/22/23 /downloads/2022/02/22/23
INFO:root:aws s3 sync s3://lnl-snowplow-washington-city-paper/enriched/good/2022/02/22/22 /downloads/2022/02/22/22
INFO:root:Uploading events data to Redshift...
INFO:botocore.credentials:Found credentials in shared credentials file: ~/.aws/credentials
INFO:root:Skipping metric write for name:downloaded_rows value:2980
INFO:root:Skipping metric write for name:written_events value:2980
INFO:root:Skipping metric write for name:download_time value:6.085413932800293
INFO:root:Fetching paths to update...
INFO:root:Inspecting 88 new paths
WARNING:root:Failed to scrape External ID for path /article/author/alona-wartofsky/page/3/ 
WARNING:root:Failed to scrape External ID for path /article/tag/brad-deboy/ 
WARNING:root:Failed to scrape External ID for path /article/tag/izakaya-seki/ 
WARNING:root:Failed to scrape External ID for path /article/tag/dc-jail/ 
WARNING:root:Failed to scrape External ID for path /article/tag/nona-eath/ 
WARNING:root:Failed to scrape External ID for path /article/author/alona-wartofsky/page/4/ 
WARNING:root:Failed to scrape External ID for path /article/tag/kal-penn/ 
WARNING:root:Failed to scrape External ID for path /article/author/alona-wartofsky/page/10/ 
WARNING:root:Failed to scrape External ID for path /article/author/alona-wartofsky/page/7/ 
WARNING:root:Failed to scrape External ID for path /article/author/alona-wartofsky/page/8/ 
WARNING:root:Failed to scrape External ID for path /article/tag/homayon-karimy/ 
WARNING:root:Failed to scrape External ID for path /article/tag/drawn-to-art/ 
WARNING:root:Failed to scrape External ID for path /article/author/alona-wartofsky/page/9/ 
WARNING:root:Failed to scrape External ID for path /article/author/jake-emen/ 
WARNING:root:Failed to scrape External ID for path /article/author/alona-wartofsky/page/6/ 
WARNING:root:Failed to scrape External ID for path /article/tag/g-gordon-liddy/ 
WARNING:root:Failed to scrape External ID for path /article/tag/jimmys-philly-steaks/ 
WARNING:root:Failed to scrape External ID for path /article/author/alona-wartofsky/page/5/ 
WARNING:root:Failed to scrape External ID for path /article/tag/michael-caine/ 
WARNING:root:Failed to scrape External ID for path /article/tag/joe-ross/ 
WARNING:root:Failed to scrape External ID for path /article/tag/ghibellina/ 
INFO:root:Scraped 10 records
INFO:root:Bulk inserting 10 records
INFO:root:Updating 0 records
INFO:root:Scraped 0 records
INFO:root:Bulk updating 0 records
INFO:root:Skipping metric write for name:article_scraping_errors value:0
INFO:root:Skipping metric write for name:article_scraping_paths_written value:88
INFO:root:Skipping metric write for name:article_scraping_total value:10
INFO:root:Skipping metric write for name:article_scraping_creates value:10
INFO:root:Skipping metric write for name:article_scraping_updates value:0
INFO:root:Skipping metric write for name:article_scraping_time value:12.436357021331787
INFO:root:Deleting stale data from devdwelltimes...
INFO:root:Writing dwell time table 2022-02-22...
INFO:root:Saving 50 default recs to db...
INFO:root:Successfully updated model id 3024 as current 'popularity' model for 'washington-city-paper'
Epoch 0: loss 0.35523992911712526
Epoch 1: loss 0.020335897766882154
Epoch 2: loss 0.020667833451787295
INFO:root:Skipping metric write for name:model_training_time value:35.489200830459595
INFO:root:Embedding similarity matrix construted
INFO:root:Total latency to find K-Nearest Neighbors: 0.6867859363555908
INFO:root:Successfully trained model on 83293 inputs.
INFO:root:Created model with id 3025
INFO:root:Successfully updated model id 3025 as current 'article' model for 'washington-city-paper'
INFO:root:found 434 models to delete, deleting a max of 10...
INFO:root:deleted model_ids: [2388, 2386, 2353, 2390, 2352, 2355, 2354, 2392, 2396, 2398]
INFO:root:Skipping metric write for name:rec_creation_time value:56.569902181625366
INFO:root:Skipping metric write for name:rec_creation_total value:41100
INFO:root:Skipping metric write for name:job_time value:122.31073522567749
```
