### PR TITLE
[update] model ttl

### DIFF
--- a/job/steps/save_predictions.py
+++ b/job/steps/save_predictions.py
@@ -42,8 +42,7 @@ def save_predictions(
 
 
 def delete_old_models() -> None:
-    # delete models older than one month
-    TTL_DAYS = 30
+    TTL_DAYS = 14
     ttl_days_ago = datetime.now(timezone.utc) - timedelta(days=TTL_DAYS)
 
     query = Model.select().where(


### PR DESCRIPTION
## description 
delete models (and associated recs) older than 14 days 

we haven't needed to reference models older than a few days and this will save us a bunch of memory in our rec db, speeding up non-cached rec requests in our api 