### PR TITLE
Troubleshoot schedule

### DIFF
--- a/cdk/lib/app-stack.ts
+++ b/cdk/lib/app-stack.ts
@@ -17,6 +17,8 @@ export interface AppStackProps extends cdk.StackProps {
 }
 
 function getSchedule(stage: helpers.STAGE, index: number) {
+  // find more scheduling options here:
+  // https://docs.aws.amazon.com/cdk/api/v1/docs/@aws-cdk_aws-applicationautoscaling.Schedule.html
   let n = partners.filter(f => f.enabled).length
   if (stage == helpers.STAGE.DEVELOPMENT) {
     // Development job runs once per day
@@ -109,8 +111,6 @@ export class AppStack extends cdk.Stack {
     });
 
     new ScheduledFargateTask(this, `${id}ScheduledFargateTask`, {
-      // find more scheduling options here:
-      // https://docs.aws.amazon.com/cdk/api/v1/docs/@aws-cdk_aws-applicationautoscaling.Schedule.html
       schedule: getSchedule(props.stage, props.index),
       desiredTaskCount: 1,
       cluster,

--- a/cdk/lib/app-stack.ts
+++ b/cdk/lib/app-stack.ts
@@ -20,23 +20,10 @@ function getSchedule(stage: helpers.STAGE, index: number) {
   let n = partners.filter(f => f.enabled).length
   if (stage == helpers.STAGE.DEVELOPMENT) {
     // Development job runs once per day
-    // Offset each development job by 1 hour.
-    let cronOptions = {
-      hour: `${index % 24}`,
-      minute: '0',
-    }
-    return Schedule.cron(cronOptions)
+    return Schedule.rate(cdk.Duration.hours(24))
   }
-  // In prod, run the job once every 2 hours.
-  // Offset the jobs evenly across 1 hour.
-  // Cron makes it really hard to do more complicated scheduling than that
-  let offset = Math.floor(60 / n) * index
-
-  let cronOptions = {
-    minute: `${offset}`,
-    hour: '0,2,4,6,8,10,12,14,16,18,20,22',
-  }
-  return Schedule.cron(cronOptions)
+  // In prod, run the job once every 3 hours.
+  return Schedule.rate(cdk.Duration.hours(3))
 }
 
 export class AppStack extends cdk.Stack {

--- a/env.json
+++ b/env.json
@@ -12,7 +12,7 @@
         "DISPLAY_PROGRESS": false,
         "MAX_RECS": 20,
         "DAYS_OF_DATA": 28,
-        "HOURS_OF_DATA": 2,
+        "HOURS_OF_DATA": 3,
         "REDSHIFT_DB_NAME": "/prod/redshift-db/name",
         "REDSHIFT_DB_PASSWORD": "/prod/redshift-db/password",
         "REDSHIFT_DB_USER": "/prod/redshift-db/user",


### PR DESCRIPTION
## description 
looks like the inquirer job takes ~3 hours to complete (see screenshot below). 

should we adjust the interval between jobs to 3 hours? potential downsides:
- not sure if job can hold 3 hours of data to preprocess in memory for pi 
- this implementation is crude and removes the even spacing of jobs over an hour 
 
<img width="831" alt="Screen Shot 2022-03-14 at 3 10 42 PM" src="https://user-images.githubusercontent.com/7977127/158243981-2749b7d2-7716-46bf-b25b-f64ebe0e0fcf.png">

