### PR TITLE
Ignore fresh external ID failures for 1 day

### DIFF
--- a/job/steps/scrape_metadata.py
+++ b/job/steps/scrape_metadata.py
@@ -108,6 +108,9 @@ def update_path_cache(
         )
 
     with db_proxy.atomic():
+        Path.delete().where(
+            Path.path.in_([c.path for c in to_create]) & (Path.site == site.name)
+        ).execute()
         Path.bulk_create(to_create, batch_size=50)
 
     write_metric("article_scraping_errors", num_unhandled_errors)

--- a/job/steps/warehouse.py
+++ b/job/steps/warehouse.py
@@ -129,6 +129,9 @@ def get_paths_to_update(site: Site, dts: List[datetime.datetime]) -> pd.DataFram
             left join {paths} p
                 on event_paths.landing_page_path = p.path
                 and p.site = '{site.name}'
+                -- ignore newly created entries, in case they change
+                -- in the next few hours (this does happen sometimes)
+                and cast(p.created_at as DATE) < current_date
             left join {articles} a
                 on p.external_id = a.external_id
                 and p.site = a.site


### PR DESCRIPTION
Sometimes we scrape a new path and it doesn't have an external ID. Then, later that day it _does_ have an external ID.

This is a problem because we save that the path has no external ID in our path cache table, meaning that that path is ignored going forward. 

This PR makes sure that we re-try any new paths that have been seen in the last day to pick up this issue.
