### PR TITLE
[change] model ttl to 1 day

### DIFF
--- a/job/steps/save_predictions.py
+++ b/job/steps/save_predictions.py
@@ -47,7 +47,7 @@ def save_predictions(
 
 
 def delete_old_models() -> None:
-    TTL_DAYS = 28
+    TTL_DAYS = 1
     ttl_days_ago = datetime.now(timezone.utc) - timedelta(days=TTL_DAYS)
 
     query = Model.select().where(


### PR DESCRIPTION
## description 
now that Sylvan has applied an index to recommendation model_id's, these deletes won't take an expensive table scan 

by aggressively cleaning up stale models and their associated recs, we'll save ourselves a lot of memory (tens instead of hundreds of millions of recommendation records at any given time)