### PR TITLE
Max article age by site

### DIFF
--- a/cdk/lib/app-stack.ts
+++ b/cdk/lib/app-stack.ts
@@ -18,15 +18,6 @@ export interface AppStackProps extends cdk.StackProps {
 
 function getCron(stage: helpers.STAGE, index: number) {
   let n = partners.filter(f => f.enabled).length
-  if (stage == helpers.STAGE.DEVELOPMENT) {
-    // Development job runs once per day
-    // Offset each development job by 1 hour.
-    return {
-      hour: `${index % 24}`,
-      minute: '0',
-    }
-  }
-  // In prod, run the job once every 2 hours.
   // Offset the jobs evenly across 1 hour.
   // Cron makes it really hard to do more complicated scheduling than that
   let offset = Math.floor(60 / n) * index

--- a/cdk/lib/partners.ts
+++ b/cdk/lib/partners.ts
@@ -18,7 +18,7 @@ export const partners: Array<Organization> = [
     pascalName: "PhiladelphiaInquirer",
     cpu: DEFAULT_CPU,
     memoryLimitMiB: DEFAULT_MEM,
-    enabled: false,
+    enabled: true,
   },
   {
     orgName: "texas-tribune",

--- a/cdk/lib/partners.ts
+++ b/cdk/lib/partners.ts
@@ -17,7 +17,7 @@ export const partners: Array<Organization> = [
     orgName: "philadelphia-inquirer",
     pascalName: "PhiladelphiaInquirer",
     cpu: DEFAULT_CPU,
-    memoryLimitMiB: DEFAULT_MEM,
+    memoryLimitMiB: 16384,
     enabled: true,
   },
   {

--- a/env.json
+++ b/env.json
@@ -27,9 +27,7 @@
         "DISPLAY_PROGRESS": true,
         "DAYS_OF_DATA": 28
     },
-    "dev": {
-        "HOURS_OF_DATA": 24
-    },
+    "dev": {},
     "prod": {
         "DB_NAME": "/prod/article-rec-db/name",
         "DB_PASSWORD": "/prod/database/password",

--- a/job/steps/warehouse.py
+++ b/job/steps/warehouse.py
@@ -243,7 +243,7 @@ def get_dwell_times(site: Site, days=28) -> pd.DataFrame:
     and num_articles_per_user > 2 
     and duration between 30 and 600
     and duration_per_user > 60
-    and {article_table}.published_at > current_date - {site.max_article_age}
+    and {article_table}.published_at > current_date - {site.max_article_age * 365}
     """
     conn = get_connection()
     with conn.cursor() as cursor:

--- a/job/steps/warehouse.py
+++ b/job/steps/warehouse.py
@@ -210,6 +210,7 @@ def get_dwell_times(site: Site, days=28) -> pd.DataFrame:
     - Removes readers who only read one article
     - Removes interactions longer than 10 minutes (600 seconds)
     - Removes users who spent less than one total minute on the site
+    - Removes articles older than a site-specific window
     """
     logging.info("Fetching dwell time data...")
     table = get_table(Table.DWELL_TIMES)
@@ -242,6 +243,7 @@ def get_dwell_times(site: Site, days=28) -> pd.DataFrame:
     and num_articles_per_user > 2 
     and duration between 30 and 600
     and duration_per_user > 60
+    and {article_table}.published_at > current_date - {site.max_article_age}
     """
     conn = get_connection()
     with conn.cursor() as cursor:

--- a/sites/philadelphia_inquirer.py
+++ b/sites/philadelphia_inquirer.py
@@ -21,6 +21,7 @@ https://www.notion.so/a8698dd6527140aaba8acfc29be40aa8?v=d30e06f348e94063ab4f451
 """
 
 POPULARITY_WINDOW = 1
+MAX_ARTICLE_AGE = 2
 DOMAIN = "www.inquirer.com"
 NAME = "philadelphia-inquirer"
 FIELDS = GOOGLE_TAG_MANAGER_RAW_FIELDS
@@ -284,4 +285,5 @@ PI_SITE = Site(
     fetch_article,
     bulk_fetch,
     POPULARITY_WINDOW,
+    MAX_ARTICLE_AGE,
 )

--- a/sites/site.py
+++ b/sites/site.py
@@ -13,6 +13,7 @@ Site = namedtuple(
         "fetch_article",
         "bulk_fetch",
         "popularity_window",
+        "max_article_age",
     ],
 )
 

--- a/sites/texas_tribune.py
+++ b/sites/texas_tribune.py
@@ -22,6 +22,7 @@ https://www.notion.so/a8698dd6527140aaba8acfc29be40aa8?v=d30e06f348e94063ab4f451
 """
 
 POPULARITY_WINDOW = 7
+MAX_ARTICLE_AGE = 10
 DOMAIN = "www.texastribune.org"
 NAME = "texas-tribune"
 FIELDS = GOOGLE_TAG_MANAGER_RAW_FIELDS
@@ -207,4 +208,5 @@ TT_SITE = Site(
     fetch_article,
     bulk_fetch,
     POPULARITY_WINDOW,
+    MAX_ARTICLE_AGE,
 )

--- a/sites/washington_city_paper.py
+++ b/sites/washington_city_paper.py
@@ -12,6 +12,7 @@ from sites.site import Site
 import pandas as pd
 
 POPULARITY_WINDOW = 7
+MAX_ARTICLE_AGE = 10
 DOMAIN = "washingtoncitypaper.com"
 NAME = "washington-city-paper"
 FIELDS = {
@@ -180,4 +181,5 @@ WCP_SITE = Site(
     fetch_article,
     bulk_fetch,
     POPULARITY_WINDOW,
+    MAX_ARTICLE_AGE,
 )


### PR DESCRIPTION
# description
add a 2-year article age threshold for philly inquirer article recommendations 

do a few extra things to get the dev job running for pi:
- double memory allocation for pi
- run dev job at same frequency as prod 

# local testing 
✅  seeing fewer recs for washington city paper (will test philly inquirer in dev) 

compare branch
```
INFO:root:Created model with id 3805
INFO:root:Writing 17640 recommendations...
```
to main
```
INFO:root:Created model with id 3803
INFO:root:Writing 26070 recommendations...
```

# dev testing 
✅ pi job runs to completion on dev and saves the expected num of recs (~300k) 
<img width="697" alt="Screen Shot 2022-04-05 at 1 09 17 PM" src="https://user-images.githubusercontent.com/7977127/161812303-0e6743cc-54b1-4e47-8314-e663d40c3189.png">

