### PR TITLE
Improve dev deploys

### DIFF
--- a/Karfile
+++ b/Karfile
@@ -8,10 +8,16 @@ DOCKER_OPTS=$(cat <<END_HEREDOC
 END_HEREDOC
 )
 
-#@cdk
-#+Run cdk.
-task-cdk() {
-    (cd cdk && npx cdk $@)
+#@deploy
+#+CDK deploy.
+task-deploy() {
+    echo "Deploying all dev stacks..."
+    cd cdk
+    for stack in $(npx cdk list | grep Dev)
+    do
+        npx cdk deploy $stack
+    done
+    cd ..
 }
 
 #@build

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ kar article-backfill --site texas-tribune --start-date 2021-12-01 --days 10
 For dev deployment, run:
 
 ```
-kar cdk deploy DevArticleRecTrainingJob
+kar deploy
 ```
 
 Each pull request to main will trigger a new prod deployment when merged.


### PR DESCRIPTION
# description
this adds helper to make dev deploys easier. now that we have a dev stack for each partner, it's tedious to deploy each stack individually without something like this 

# local testing
✅ `kar deploy` command works as expected 