### PR TITLE
[change] reorder schedule

### DIFF
--- a/cdk/lib/partners.ts
+++ b/cdk/lib/partners.ts
@@ -14,18 +14,17 @@ export const partners: Array<Organization> = [
     enabled: true,
   },
   {
-    orgName: "philadelphia-inquirer",
-    pascalName: "PhiladelphiaInquirer",
-    cpu: DEFAULT_CPU,
-    memoryLimitMiB: 16384,
-    enabled: true,
-  },
-  {
     orgName: "texas-tribune",
     pascalName: "TexasTribune",
     cpu: DEFAULT_CPU,
     memoryLimitMiB: DEFAULT_MEM,
     enabled: true,
   },
-
+  {
+    orgName: "philadelphia-inquirer",
+    pascalName: "PhiladelphiaInquirer",
+    cpu: DEFAULT_CPU,
+    memoryLimitMiB: 16384,
+    enabled: true,
+  },
 ]


### PR DESCRIPTION
## description
re-order schedule so shorter job (texas tribune) goes first and the inquirer gets more room to run on its own

## testing
deployed to dev, prod diff looks as expected 
```
~/lnl/article-rec-training-job/cdk [reorder-schedule] npx cdk diff PhiladelphiaInquirerArticleRecTrainingJob 
Including dependency stacks: ArticleRecTrainingJobCentralResourcesStack
Stack ArticleRecTrainingJobCentralResourcesStack
There were no differences
Stack PhiladelphiaInquirerArticleRecTrainingJob
Resources
[~] AWS::ECS::TaskDefinition PhiladelphiaInquirerArticleRecTrainingJobTaskDefinition PhiladelphiaInquirerArticleRecTrainingJobTaskDefinition7D26D8FF replace
 └─ [~] ContainerDefinitions (requires replacement)
     └─ @@ -24,7 +24,7 @@
        [ ]       {
        [ ]         "Ref": "AWS::URLSuffix"
        [ ]       },
        [-]       "/aws-cdk/assets:3b7f19c6206b9a95dd87f1ab61a357caa5fa0788afd0e3a6452fe898415629f0"
        [+]       "/aws-cdk/assets:67a43a80fb3ef36aa3a979022dd67c6455dbba545197ac30a910778f0094ecc2"
        [ ]     ]
        [ ]   ]
        [ ] },
[~] AWS::Events::Rule PhiladelphiaInquirerArticleRecTrainingJobScheduledFargateTask/ScheduledEventRule PhiladelphiaInquirerArticleRecTrainingJobScheduledFargateTaskScheduledEventRuleB30D4DAE 
 └─ [~] ScheduleExpression
     ├─ [-] cron(20 0,2,4,6,8,10,12,14,16,18,20,22 * * ? *)
     └─ [+] cron(40 0,2,4,6,8,10,12,14,16,18,20,22 * * ? *)

~/lnl/article-rec-training-job/cdk [reorder-schedule] npx cdk diff TexasTribuneArticleRecTrainingJob        
Including dependency stacks: ArticleRecTrainingJobCentralResourcesStack
Stack ArticleRecTrainingJobCentralResourcesStack
There were no differences
Stack TexasTribuneArticleRecTrainingJob
Resources
[~] AWS::ECS::TaskDefinition TexasTribuneArticleRecTrainingJobTaskDefinition TexasTribuneArticleRecTrainingJobTaskDefinitionC3122BCB replace
 └─ [~] ContainerDefinitions (requires replacement)
     └─ @@ -24,7 +24,7 @@
        [ ]       {
        [ ]         "Ref": "AWS::URLSuffix"
        [ ]       },
        [-]       "/aws-cdk/assets:b42f2632be72eaec2fa57952281b089b43bd5642407b9ae6f930aa46a41b17ec"
        [+]       "/aws-cdk/assets:f43ff2771e8e78d6350555bbd1c2c3a3449733b124f6d5301f2ab52b45804076"
        [ ]     ]
        [ ]   ]
        [ ] },
[~] AWS::Events::Rule TexasTribuneArticleRecTrainingJobScheduledFargateTask/ScheduledEventRule TexasTribuneArticleRecTrainingJobScheduledFargateTaskScheduledEventRule6EA77A4D 
 └─ [~] ScheduleExpression
     ├─ [-] cron(40 0,2,4,6,8,10,12,14,16,18,20,22 * * ? *)
     └─ [+] cron(20 0,2,4,6,8,10,12,14,16,18,20,22 * * ? *)
```