### PR TITLE
[change] improve metadata scraping warnings

### DIFF
--- a/job/steps/scrape_metadata.py
+++ b/job/steps/scrape_metadata.py
@@ -143,7 +143,8 @@ def extract_external_ids(
                 results.append(result)
             except ArticleScrapingError as e:
                 logging.warning(
-                    f"Failed to scrape External ID for path {e.path}. "
+                    "Failed to scrape external ID. "
+                    + f"Path: {e.path}. "
                     + f"Type: {e.error_type}. "
                     + f"Message: {e.msg}"
                 )
@@ -196,7 +197,10 @@ def scrape_articles(
                 results.append(result)
             except ArticleScrapingError as e:
                 logging.warning(
-                    f"ArticleScrapingError! {e.error_type}, {e.path}, {e.msg}"
+                    f"Failed to scrape article!! "
+                    + f"Path: {e.path}. "
+                    + f"Type: {e.error_type}. "
+                    + f"Message: {e.msg}"
                 )
                 errors.append(e)
 

--- a/job/steps/scrape_metadata.py
+++ b/job/steps/scrape_metadata.py
@@ -143,7 +143,9 @@ def extract_external_ids(
                 results.append(result)
             except ArticleScrapingError as e:
                 logging.warning(
-                    f"Failed to scrape External ID for path {e.path} {e.msg}"
+                    f"Failed to scrape External ID for path {e.path}. "
+                    + f"Type: {e.error_type}. "
+                    + f"Message: {e.msg}"
                 )
                 results.append(e)
     return results

--- a/sites/philadelphia_inquirer.py
+++ b/sites/philadelphia_inquirer.py
@@ -105,23 +105,22 @@ def extract_external_id(path: str) -> Optional[str]:
         ) from e
 
     if "_id" not in res:
-        raise ArticleScrapingError(ScrapeFailure.NO_EXTERNAL_ID, path, external_id=None, msg="External ID not detected in response")
+        raise ArticleScrapingError(ScrapeFailure.NO_EXTERNAL_ID, path, external_id=None,
+                                   msg="External ID not detected in response")
 
     external_id = res["_id"]
 
     IN_HOUSE_PLATFORMS = {"composer", "ellipsis"}
     if res.get("source", {}).get("system") not in IN_HOUSE_PLATFORMS:
-        error_msg = "Not in-house article"
         raise ArticleScrapingError(
-            ScrapeFailure.FAILED_SITE_VALIDATION, path, str(external_id), error_msg
+            ScrapeFailure.FAILED_SITE_VALIDATION, path, str(external_id), "Not in-house article"
         )
 
     TEST_SITE = "/zzz-systest"
     sites = res.get("taxonomy", {}).get("sites", [])
     if sites and sites[0].get("_id") == TEST_SITE:
-        error_msg = "Test article"
         raise ArticleScrapingError(
-            ScrapeFailure.FAILED_SITE_VALIDATION, path, str(external_id), error_msg
+            ScrapeFailure.FAILED_SITE_VALIDATION, path, str(external_id), "Test article"
         )
 
     return external_id
@@ -204,9 +203,8 @@ def parse_article_metadata(
         try:
             val = func(res)
         except Exception as e:
-            msg = f"Error parsing {prop}"
             raise ArticleScrapingError(
-                ScrapeFailure.FETCH_ERROR, path, external_id, msg
+                ScrapeFailure.FETCH_ERROR, path, external_id, f"Error parsing {prop}"
             ) from e
         metadata[prop] = val
 
@@ -260,9 +258,8 @@ def fetch_article(external_id: str, path: str) -> Response:
     try:
         res = safe_get(API_URL, API_HEADER, params, SCRAPE_CONFIG)
     except Exception as e:
-        msg = f"Error fetching article url: {API_URL}"
         raise ArticleScrapingError(
-            ScrapeFailure.FETCH_ERROR, path, external_id, msg
+            ScrapeFailure.FETCH_ERROR, path, external_id, f"Error fetching article URL: {API_URL}"
         ) from e
 
     error_msg = validate_response(res)

--- a/sites/philadelphia_inquirer.py
+++ b/sites/philadelphia_inquirer.py
@@ -101,11 +101,11 @@ def extract_external_id(path: str) -> Optional[str]:
         res = res.json()
     except Exception as e:
         raise ArticleScrapingError(
-            ScrapeFailure.FETCH_ERROR, path, external_id=None
+            ScrapeFailure.FETCH_ERROR, path, external_id=None, msg="ARC API request failed"
         ) from e
 
     if "_id" not in res:
-        raise ArticleScrapingError(ScrapeFailure.NO_EXTERNAL_ID, path, external_id=None)
+        raise ArticleScrapingError(ScrapeFailure.NO_EXTERNAL_ID, path, external_id=None, msg="External ID not detected in response")
 
     external_id = res["_id"]
 

--- a/sites/texas_tribune.py
+++ b/sites/texas_tribune.py
@@ -89,7 +89,7 @@ def bulk_fetch(
 def extract_external_id(path: str) -> str:
     for prefix in NON_ARTICLE_PREFIXES:
         if path.startswith(prefix):
-            msg = f"Skipping non-article path: {path}"
+            msg = "Skipping non-article path"
             raise ArticleScrapingError(
                 ScrapeFailure.NO_EXTERNAL_ID, path, external_id=None, msg=msg
             )
@@ -102,7 +102,7 @@ def extract_external_id(path: str) -> str:
             ScrapeFailure.FETCH_ERROR,
             path,
             external_id=None,
-            msg=f"External ID fetch failed for {article_url}",
+            msg=f"API request failed for {article_url}",
         ) from e
     soup = BeautifulSoup(page.text, features="html.parser")
 
@@ -158,7 +158,7 @@ def parse_metadata(
         try:
             val = func(api_info)
         except Exception as e:
-            msg = "error parsing metadata for article"
+            msg = "Error parsing metadata for article"
             raise ArticleScrapingError(
                 ScrapeFailure.MALFORMED_RESPONSE, external_id, path, msg
             ) from e
@@ -172,7 +172,7 @@ def scrape_article_metadata(page: Response, external_id: str, path: str) -> dict
         api_info = page.json()
     except Exception as e:
         raise ArticleScrapingError(
-            ScrapeFailure.FETCH_ERROR, path, external_id, "JSON parse failed"
+            ScrapeFailure.FETCH_ERROR, path, external_id, "Response JSON parse failed"
         ) from e
     metadata = parse_metadata(api_info, external_id, path)
     return metadata

--- a/sites/texas_tribune.py
+++ b/sites/texas_tribune.py
@@ -89,9 +89,8 @@ def bulk_fetch(
 def extract_external_id(path: str) -> str:
     for prefix in NON_ARTICLE_PREFIXES:
         if path.startswith(prefix):
-            msg = "Skipping non-article path"
             raise ArticleScrapingError(
-                ScrapeFailure.NO_EXTERNAL_ID, path, external_id=None, msg=msg
+                ScrapeFailure.NO_EXTERNAL_ID, path, external_id=None, msg="Skipping non-article path"
             )
 
     article_url = f"https://{DOMAIN}{path}"
@@ -158,9 +157,8 @@ def parse_metadata(
         try:
             val = func(api_info)
         except Exception as e:
-            msg = "Error parsing metadata for article"
             raise ArticleScrapingError(
-                ScrapeFailure.MALFORMED_RESPONSE, external_id, path, msg
+                ScrapeFailure.MALFORMED_RESPONSE, external_id, path, "Error parsing metadata for article"
             ) from e
         metadata[prop] = val
 
@@ -189,9 +187,8 @@ def fetch_article(
     try:
         res = safe_get(api_url, scrape_config=SCRAPE_CONFIG)
     except Exception as e:
-        msg = f"Error fetching article url: {api_url}"
         raise ArticleScrapingError(
-            ScrapeFailure.FETCH_ERROR, path, external_id, msg
+            ScrapeFailure.FETCH_ERROR, path, external_id, f"Error fetching article url: {api_url}"
         ) from e
 
     return res

--- a/sites/washington_city_paper.py
+++ b/sites/washington_city_paper.py
@@ -88,7 +88,8 @@ def extract_external_id(path: str) -> str:
     if result:
         return result.groups()[2]
     else:
-        raise ArticleScrapingError(ScrapeFailure.NO_EXTERNAL_ID, path, external_id=None)
+        msg = "External ID not found in path"
+        raise ArticleScrapingError(ScrapeFailure.NO_EXTERNAL_ID, path, external_id=None, msg=msg)
 
 
 def scrape_title(page: Response, soup: BeautifulSoup) -> str:
@@ -123,7 +124,7 @@ def scrape_article_metadata(page: Response, external_id: str, path: str) -> dict
         try:
             val = func(page, soup)
         except Exception as e:
-            msg = f"Error scraping {prop} for article path: {path}"
+            msg = f"Error scraping {prop} for article path"
             raise ArticleScrapingError(
                 ScrapeFailure.MALFORMED_RESPONSE, path, external_id, msg=msg
             ) from e
@@ -156,8 +157,9 @@ def fetch_article(external_id: str, path: str) -> Response:
     try:
         page = safe_get(url)
     except Exception as e:
+        msg = f"Request failed for {url}"
         raise ArticleScrapingError(
-            ScrapeFailure.FETCH_ERROR, path, str(external_id)
+            ScrapeFailure.FETCH_ERROR, path, str(external_id), msg=msg
         ) from e
     soup = BeautifulSoup(page.text, features="html.parser")
 

--- a/sites/washington_city_paper.py
+++ b/sites/washington_city_paper.py
@@ -88,8 +88,8 @@ def extract_external_id(path: str) -> str:
     if result:
         return result.groups()[2]
     else:
-        msg = "External ID not found in path"
-        raise ArticleScrapingError(ScrapeFailure.NO_EXTERNAL_ID, path, external_id=None, msg=msg)
+        raise ArticleScrapingError(ScrapeFailure.NO_EXTERNAL_ID, path, external_id=None,
+                                   msg="External ID not found in path")
 
 
 def scrape_title(page: Response, soup: BeautifulSoup) -> str:
@@ -124,9 +124,8 @@ def scrape_article_metadata(page: Response, external_id: str, path: str) -> dict
         try:
             val = func(page, soup)
         except Exception as e:
-            msg = f"Error scraping {prop} for article path"
             raise ArticleScrapingError(
-                ScrapeFailure.MALFORMED_RESPONSE, path, external_id, msg=msg
+                ScrapeFailure.MALFORMED_RESPONSE, path, external_id, f"Error scraping {prop} for article path"
             ) from e
         metadata[prop] = val
 
@@ -157,9 +156,8 @@ def fetch_article(external_id: str, path: str) -> Response:
     try:
         page = safe_get(url)
     except Exception as e:
-        msg = f"Request failed for {url}"
         raise ArticleScrapingError(
-            ScrapeFailure.FETCH_ERROR, path, str(external_id), msg=msg
+            ScrapeFailure.FETCH_ERROR, path, str(external_id), f"Request failed for {url}"
         ) from e
     soup = BeautifulSoup(page.text, features="html.parser")
 


### PR DESCRIPTION
## Description
- Added a message to when `ArticleScrapingError` is thrown in several places
- Made warnings logged by `scrape_metadata.py` show the type of ArticleScrapingError being raised in addition to the path and message

Both of these changes should make it easier to detect potential scraping problems when looking at CloudWatch logs