### PR TITLE
add truncatecolumns option to redshift copy

### DIFF
--- a/job/steps/warehouse.py
+++ b/job/steps/warehouse.py
@@ -87,6 +87,7 @@ def write_events(
                 DELIMITER AS '\t'
                 DATEFORMAT 'YYYY-MM-DD'
                 IGNOREHEADER 1
+                TRUNCATECOLUMNS
                 csv;
             """
         )


### PR DESCRIPTION
add the TRUNCATECOLUMNS option to the redshift copy command so that any paths that are somehow too long don't break the copy. This is a rough fix that makes sure we don't hit the "data too long" issue, and pushes the issue to the code that will ignore it as a valid URL further along in the pipeline. It will not be included in the model.

Ran changes locally with the site that caused the issue in the first place, and it did not error. It also logged the invalid path where we expected.