### PR TITLE
[change] crude WCP rate-limiting

### DIFF
--- a/sites/washington_city_paper.py
+++ b/sites/washington_city_paper.py
@@ -33,8 +33,8 @@ TRAINING_PARAMS = {
 }
 
 SCRAPE_CONFIG = {
-    "concurrent_requests": 20,
-    "requests_per_second": None,
+    "concurrent_requests": 1,
+    "requests_per_second": 2,
 }
 
 # supported url path formats:


### PR DESCRIPTION
## Description
From time to time, we'd get messages like these in the CloudWatch logs for WCP,

![image](https://user-images.githubusercontent.com/57234880/174908029-8eedef22-32bc-44d8-a7b5-f0f61dd2ca99.png)

which, upon further inspection, happened because the HTML scraped indicated a 429 rate-limiting error instead of containing content of an actual article:

```html
<html lang="en">
<head>
<meta charset="utf-8"/>
<title>429 Too Many Requests</title>
<meta content="" name="description"/>
<meta content="" name="author"/>
```

This PR throttles the rate of scraping WCP articles. As a result, job time might increase, which we need to monitor closely. Conversations with WCP down the line can help fine-tune the number of concurrent requests and wait time if needed.