### PR TITLE
[add] http error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ Brewfile.lock.json
 *.DS_Store
 data.gz
 tmp/*
+.vscode

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "python.formatting.provider": "black"
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.formatting.provider": "black"
+}

--- a/sites/helpers.py
+++ b/sites/helpers.py
@@ -90,15 +90,11 @@ def safe_get(
 
 
 def validate_response(page: Response, validate_funcs: List[ResponseValidator]) -> Optional[str]:
-    error_msg = None
-
     # Go through validation functions one by one, stop as soon as a message gets returned
     for func in validate_funcs:
         error_msg = func(page)
         if error_msg is not None:
-            break
-
-    return error_msg
+            return error_msg
 
 
 def validate_status_code(page: Response) -> Optional[str]:
@@ -106,7 +102,7 @@ def validate_status_code(page: Response) -> Optional[str]:
         # Raise HTTPError if error code is 400 or more
         page.raise_for_status()
     except HTTPError as e:
-        return f'Request failed with error code {page.status_code} and message "{str(e)}"'
+        return f'Request failed with error code {page.status_code} and message "{e}"'
 
     # Would be curious to see non-200 responses that still go through
     if page.status_code != 200:

--- a/sites/helpers.py
+++ b/sites/helpers.py
@@ -6,7 +6,8 @@ from typing import Callable, Dict, List, Optional
 
 import pandas as pd
 import requests as req
-from requests.models import HTTPError, Response
+from requests.exceptions import HTTPError
+from requests.models import Response
 from retrying import retry
 
 GOOGLE_TAG_MANAGER_RAW_FIELDS = {

--- a/sites/helpers.py
+++ b/sites/helpers.py
@@ -17,6 +17,9 @@ GOOGLE_TAG_MANAGER_RAW_FIELDS = {
     "page_urlpath",
 }
 
+# Custom types
+ResponseValidator = Callable[[Response], Optional[str]]
+
 
 def ms_timestamp(dt: datetime) -> float:
     epoch = datetime.utcfromtimestamp(0)
@@ -86,7 +89,7 @@ def safe_get(
     return page
 
 
-def validate_response(page: Response, validate_funcs: List[Callable]) -> Optional[str]:
+def validate_response(page: Response, validate_funcs: List[ResponseValidator]) -> Optional[str]:
     error_msg = None
 
     # Go through validation functions one by one, stop as soon as a message gets returned

--- a/sites/philadelphia_inquirer.py
+++ b/sites/philadelphia_inquirer.py
@@ -12,6 +12,8 @@ from sites.helpers import (
     ms_timestamp,
     safe_get,
     transform_data_google_tag_manager,
+    validate_response,
+    validate_status_code,
 )
 from sites.site import Site
 
@@ -197,7 +199,7 @@ def parse_article_metadata(page: Union[Response, dict], external_id: str, path: 
     return metadata
 
 
-def validate_response(res: Response) -> Optional[str]:
+def validate_attributes(res: Response) -> Optional[Union[Exception, str]]:
     """ARC API response validator
 
     :res: ARC API JSON response payload
@@ -246,7 +248,7 @@ def fetch_article(external_id: str, path: str) -> Response:
             ScrapeFailure.FETCH_ERROR, path, external_id, f"Error fetching article URL: {API_URL}"
         ) from e
 
-    error_msg = validate_response(res)
+    error_msg = validate_response(res, [validate_status_code, validate_attributes])
     if error_msg:
         raise ArticleScrapingError(ScrapeFailure.MALFORMED_RESPONSE, path, external_id, error_msg)
 

--- a/sites/philadelphia_inquirer.py
+++ b/sites/philadelphia_inquirer.py
@@ -224,8 +224,6 @@ def validate_attributes(res: Response) -> Optional[str]:
     except Exception as e:
         return f"Cannot parse date of publication: {e}"
 
-    return None
-
 
 def fetch_article(external_id: str, path: str) -> Response:
     """Fetch and validate article from the ARC API

--- a/sites/philadelphia_inquirer.py
+++ b/sites/philadelphia_inquirer.py
@@ -199,7 +199,7 @@ def parse_article_metadata(page: Union[Response, dict], external_id: str, path: 
     return metadata
 
 
-def validate_attributes(res: Response) -> Optional[Union[Exception, str]]:
+def validate_attributes(res: Response) -> Optional[str]:
     """ARC API response validator
 
     :res: ARC API JSON response payload
@@ -208,7 +208,7 @@ def validate_attributes(res: Response) -> Optional[Union[Exception, str]]:
     try:
         res = res.json()
     except Exception as e:
-        return e
+        return f"Cannot parse article response JSON: {e}"
 
     if "headlines" not in res or ("headlines" in res and "basic" not in res["headlines"]):
         return "Article missing headline"
@@ -222,7 +222,7 @@ def validate_attributes(res: Response) -> Optional[Union[Exception, str]]:
     try:
         datetime.strptime(res["publish_date"], "%Y-%m-%dT%H:%M:%S.%fZ").isoformat()
     except Exception as e:
-        return e
+        return f"Cannot parse date of publication: {e}"
 
     return None
 

--- a/sites/texas_tribune.py
+++ b/sites/texas_tribune.py
@@ -13,6 +13,8 @@ from sites.helpers import (
     ScrapeFailure,
     safe_get,
     transform_data_google_tag_manager,
+    validate_response,
+    validate_status_code,
 )
 from sites.site import Site
 
@@ -184,6 +186,10 @@ def fetch_article(
         raise ArticleScrapingError(
             ScrapeFailure.FETCH_ERROR, path, external_id, f"Error fetching article url: {api_url}"
         ) from e
+
+    error_msg = validate_response(res, [validate_status_code])
+    if error_msg is not None:
+        raise ArticleScrapingError(ScrapeFailure.FAILED_SITE_VALIDATION, path, str(external_id), error_msg)
 
     return res
 

--- a/sites/washington_city_paper.py
+++ b/sites/washington_city_paper.py
@@ -131,20 +131,18 @@ def scrape_article_metadata(page: Response, external_id: str, path: str) -> dict
 
 
 def validate_not_excluded(page: Response) -> Optional[str]:
-    error_msg = None
     soup = BeautifulSoup(page.text, features="html.parser")
     primary = soup.find(id="primary")
 
+    # TODO: This looks very weird. Really don't think we should be returning None
     if not primary:
         # non-article page
-        return error_msg
+        return
 
     classes = {value for element in primary.find_all(class_=True) for value in element["class"]}
 
     if "tag-exclude" in classes:
-        error_msg = "Article has exclude tag"
-
-    return error_msg
+        return "Article has exclude tag"
 
 
 def fetch_article(external_id: str, path: str) -> Response:

--- a/tests/sites/test_helpers.py
+++ b/tests/sites/test_helpers.py
@@ -1,0 +1,58 @@
+import pytest
+from requests.models import Response
+
+from sites.helpers import validate_response, validate_status_code
+
+
+def _create_response(status_code: int) -> Response:
+    response = Response()
+    response.status_code = status_code
+    return response
+
+
+def _validate_good(response: Response) -> None:
+    return None
+
+
+def _validate_bad(response: Response) -> None:
+    return "Some error message"
+
+
+@pytest.fixture(scope="module")
+def response_good() -> Response:
+    return _create_response(200)
+
+
+@pytest.fixture(scope="module")
+def response_bad() -> Response:
+    return _create_response(404)
+
+
+def test_validate_status_code__good(response_good: Response) -> None:
+    msg = validate_status_code(response_good)
+    assert msg is None
+
+
+def test_validate_stauts_code__bad(response_bad: Response) -> None:
+    msg = validate_status_code(response_bad)
+    assert type(msg) is str
+
+
+def test_validate_response__single_good() -> None:
+    msg = validate_response(Response(), [_validate_good])
+    assert msg is None
+
+
+def test_validate_response__single_bad() -> None:
+    msg = validate_response(Response(), [_validate_bad])
+    assert type(msg) is str
+
+
+def test_validate_response__multiple_good() -> None:
+    msg = validate_response(Response(), [_validate_good, _validate_good])
+    assert msg is None
+
+
+def test_validate_response__multiple_bad() -> None:
+    msg = validate_response(Response(), [_validate_good, _validate_bad])
+    assert type(msg) is str


### PR DESCRIPTION
## Description
One insight from #136 is that it would be great to catch HTTP errors before actually looking at the response HTML. This PR adds an extra layer of validation, which inspects the response code, to the process of fetching articles from our partner news sites. It also consolidates the different ways we validate responses from different publications into one customizable `validate_response()` pipeline. 

## Testing
All tests passed locally, although I'm yet to add unit tests for the added functions.