### PR TITLE
Update save predictions

### DIFF
--- a/db/helpers.py
+++ b/db/helpers.py
@@ -91,15 +91,19 @@ def _delete_resources(mapping_class: Type[BaseMapping], conditions: Expression) 
 
 
 def set_stale_model(model_type: ModelType, model_site: str) -> None:
-    current_model_query = (Model.type == model_type) & (Model.status == Status.CURRENT.value) & (Model.site == model_site)
+    current_model_query = (
+        (Model.type == model_type.value) & (Model.status == Status.CURRENT.value) & (Model.site == model_site)
+    )
     _update_resources(Model, current_model_query, status=Status.STALE.value)
 
 
 def get_stale_model_ids(model_type: ModelType, model_site: str) -> List[int]:
-    stale_model_query = (Model.type == model_type) & (Model.status == Status.STALE.value) & (Model.site == model_site)
+    stale_model_query = (
+        (Model.type == model_type.value) & (Model.status == Status.STALE.value) & (Model.site == model_site)
+    )
     query = Model.select(Model.id).where(stale_model_query)
     stale_model_ids = [res.id for res in query]
-    logging.info(f"Found {len(stale_model_ids)} stale '{model_type}' models")
+    logging.info(f"Found {len(stale_model_ids)} stale '{model_type.value}' models")
     return stale_model_ids
 
 
@@ -117,7 +121,7 @@ def set_current_model(model_id: int, model_type: ModelType, model_site: str) -> 
     # delete stale models
     delete_models(stale_model_ids[:MAX_DELETES])
 
-    logging.info(f"Successfully updated model id {model_id} as current '{model_type}' model'")
+    logging.info(f"Successfully updated model id {model_id} as current '{model_type.value}' model'")
 
 
 def get_articles_by_path(site: str, paths: List[str]) -> List[Article]:

--- a/job/steps/save_defaults.py
+++ b/job/steps/save_defaults.py
@@ -44,5 +44,5 @@ def save_defaults(top_articles: pd.DataFrame, site: Site, experiment_date: datet
     with db_proxy.atomic():
         Rec.bulk_create(to_create, batch_size=50)
 
-    set_current_model(model_id, ModelType.POPULARITY.value, model_site=site.name)
+    set_current_model(model_id, ModelType.POPULARITY, model_site=site.name)
     return model_id

--- a/job/steps/save_predictions.py
+++ b/job/steps/save_predictions.py
@@ -32,7 +32,7 @@ def save_predictions(
         time.sleep(0.05)
 
     logging.info(f"Updating model objects in DB")
-    set_current_model(model_id, ModelType.ARTICLE.value, site.name)
+    set_current_model(model_id, ModelType.ARTICLE, site.name)
 
     latency = time.time() - start_ts
     write_metric("rec_creation_time", latency, unit=Unit.SECONDS)

--- a/job/steps/save_predictions.py
+++ b/job/steps/save_predictions.py
@@ -11,16 +11,13 @@ from sites.site import Site
 
 
 @refresh_db
-def save_predictions(
-    site: Site,
-    recs: List[Rec],
-) -> None:
+def save_predictions(site: Site, recs: List[Rec], model_type: ModelType = ModelType.ARTICLE) -> None:
     """
     Save predictions to the db
     """
     start_ts = time.time()
     # Create new model object in DB
-    model_id = create_model(type=ModelType.ARTICLE.value, site=site.name)
+    model_id = create_model(type=model_type.value, site=site.name)
     logging.info(f"Created model with id {model_id}")
     for rec in recs:
         rec.model_id = model_id
@@ -32,7 +29,7 @@ def save_predictions(
         time.sleep(0.05)
 
     logging.info(f"Updating model objects in DB")
-    set_current_model(model_id, ModelType.ARTICLE, site.name)
+    set_current_model(model_id, model_type, site.name)
 
     latency = time.time() - start_ts
     write_metric("rec_creation_time", latency, unit=Unit.SECONDS)


### PR DESCRIPTION
Update the save_predictions function to accept a model_type argument and set the default case to `ModelType.ARTICLE` so as to maintain current behavior. Makes a few changes to some DB helper functions as well to make proper use of the `ModelType` enumeration. This allows us to use this same function in the future to save recommendations generated by different types of models.