### PR TITLE
"Fix" Spotlight `IndexError` bug

### DIFF
--- a/job/job.py
+++ b/job/job.py
@@ -70,6 +70,9 @@ def run():
         logging.exception("Job failed")
         status = "failure"
 
+        # TODO: This if-block is only here while we're trying to fix the PyTorch IndexError
+        # (https://github.com/LocalAtBrown/article-rec-training-job/pull/140).
+        # Once no longer necessary, it'll need to be removed.
         if isinstance(e, IndexError) and "Dimension out of range" in str(e):
             logging.info(
                 "IndexError encountered, probably during model fitting. Saving training data and params for future inspection."

--- a/job/steps/train_model.py
+++ b/job/steps/train_model.py
@@ -37,7 +37,7 @@ def _spotlight_transform(prepared_df: pd.DataFrame, batch_size: int, random_seed
         index_to_drop = np.random.default_rng(random_seed).choice(
             prepared_df[prepared_df["external_id"] == id_article_most_read].index, size=1, replace=False, shuffle=False
         )
-        # Drop in-place
+        # Drop row with said index
         prepared_df = prepared_df.drop(index=index_to_drop)
         logging.warning(
             f"Found {num_interactions} reader-article interactions, which leaves a remainder of 1 when divided by a batch size of {batch_size} and would trigger a Spotlight bug. "

--- a/job/steps/train_model.py
+++ b/job/steps/train_model.py
@@ -27,6 +27,8 @@ def _spotlight_transform(prepared_df: pd.DataFrame, batch_size: int, random_seed
     #
     # Until this Spotlight bug is fixed, as a short-term measure, we randomly remove 1 entry from the
     # DataFrame corresponding to the article with the highest view count so as to minimally affect performance.
+    #
+    # There's a also a test for this: test_article_recommendations_spotlight_batchsize() in tests/test_helpers.py
     num_interactions = prepared_df.shape[0]
     if num_interactions % batch_size == 1:
         # External ID of most read article

--- a/job/steps/trainer.py
+++ b/job/steps/trainer.py
@@ -84,6 +84,7 @@ class Trainer:
                 loss=self.params["loss"],
                 random_state=self.params["random_state"],
                 embedding_dim=self.params["embedding_dim"],
+                batch_size=self.params["batch_size"],
             )
         elif self.params["model"] == "EMF":
             self.model = ExplicitFactorizationModel(
@@ -91,6 +92,7 @@ class Trainer:
                 loss=self.params["loss"],
                 random_state=self.params["random_state"],
                 embedding_dim=self.params["embedding_dim"],
+                batch_size=self.params["batch_size"],
             )
 
     def _normalize_embeddings(self, embedding_matrix: np.ndarray) -> np.ndarray:

--- a/job/steps/trainer.py
+++ b/job/steps/trainer.py
@@ -38,16 +38,17 @@ class Trainer:
             "hl": 10,
             "epochs": 2,
             "embedding_dim": 350,
+            "batch_size": 256,
             "model": "EMF",
             "tune": False,
-            "random_state": np.random.RandomState(42),
+            "random_seed": 42,
             "loss": "pointwise",
         }
-        self._update_params(params)
+        self._update_params({"random_state": np.random.RandomState(self.params["random_seed"]), **params})
         self.experiment_time = pd.to_datetime(experiment_time)
 
         if warehouse_transform:
-            warehouse_df = warehouse_transform(warehouse_df)
+            warehouse_df = warehouse_transform(warehouse_df, **self.params)
 
         self.spotlight_dataset = self._generate_interactions(warehouse_df)
         self.dates_df = self._generate_datedecays(warehouse_df)

--- a/job/steps/trainer.py
+++ b/job/steps/trainer.py
@@ -44,7 +44,8 @@ class Trainer:
             "random_seed": 42,
             "loss": "pointwise",
         }
-        self._update_params({"random_state": np.random.RandomState(self.params["random_seed"]), **params})
+        self._update_params({"random_state": np.random.RandomState(self.params["random_seed"])})
+        self._update_params(params)
         self.experiment_time = pd.to_datetime(experiment_time)
 
         if warehouse_transform:

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -119,3 +119,26 @@ def test_article_recommendations(external_ids, user_ids, durations, session_date
     embeddings = model.model_embeddings
     distances, nearest_indices = _test_similarities(embeddings, n_recs, decays)
     _test_orders(n_recs, nearest_indices, distances, np.unique(article_ids))
+
+
+def test_article_recommendations_spotlight_batchsize(
+    external_ids, user_ids, durations, session_dates, publish_dates, article_ids, decays
+):
+    """
+    Makes sure that any fix for the Spotlight `squeeze()` bug (see https://github.com/maciejkula/spotlight/issues/107)
+    actually works, i.e., runs smoothly and doesn't return an IndexError.
+    """
+    warehouse_df = pd.DataFrame(
+        {
+            "client_id": user_ids,
+            "external_id": external_ids,
+            "article_id": article_ids,
+            "duration": durations,
+            "published_at": publish_dates,
+            "session_date": session_dates,
+        }
+    )
+    # Set batch_size such that length of dataset % batch_size == 1 to trigger error
+    params = {"model": "IMF", "loss": "adaptive_hinge", "batch_size": len(external_ids) - 1}
+    model = Trainer(warehouse_df, datetime.now().date(), _spotlight_transform, params)
+    model.fit()

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -114,7 +114,6 @@ def test_article_recommendations(external_ids, user_ids, durations, session_date
         }
     )
     params = {"epochs": 35, "embedding_dim": 16, "model": "IMF"}
-    _spotlight_transform(warehouse_df)
     model = Trainer(warehouse_df, datetime.now().date(), _spotlight_transform, params)
     model.fit()
     embeddings = model.model_embeddings


### PR DESCRIPTION
## Description
This PR applies a short-term workaround to the Spotlight `IndexError` we've been running into and was able to reproduce (see #140). The reason, it turns out, is a [bug in the Spotlight source code](https://github.com/maciejkula/spotlight/issues/107) that gets triggered if the IMF model's batch size (256, by default) divides the total number of interactions passed to it with a remainder of 1, i.e., `num_interactions % batch_size == 1`.

The "fix" is as follows: during a job run, if the job sees that `num_interactions % batch_size == 1`, it removes 1 interaction from the interactions dataset to make the remainder no longer 1, thus avoiding the error. The interaction to remove is selected randomly among a subset of interactions involving the most frequently interacted/viewed article, i.e., the article having the most rows in the dataset, so as to minimize the effect on model performance. (The rationale is thus: Suppose articles A gets viewed by 20,000 different readers and article B by 10 different ones. The influence of 1 view of B to how the IMF model calculates B's embeddings is much greater than that of 1 view of A to how the model calculates A's embeddings; therefore, removing A's view yields a smaller effect on performance than removing B's view.)

We can remove this workaround once Spotlight's author fixes the aforementioned bug, although that seems to be unlikely given how inactive the Spotlight repo looks.

Finally, we'll also keep the diagnostic code added in #140 for now, should a similar error still appears. If everything looks good after a month or so, we can remove that code.

## Testing
All tests passed. I also added a new test, [`test_article_recommendations_spotlight_batchsize()`](https://github.com/LocalAtBrown/article-rec-training-job/blob/228e22931a79c0ef7070c15b6a204f4aca9795ff/tests/test_helpers.py#L124-L144) that attempts to fit the model given `num_interactions % batch_size == 1`. If the "fix" works as expected, no `IndexError` gets raised and the code passes the test.