### PR TITLE
"Fix" Spotlight `IndexError` bug 2.0

### DIFF
--- a/job/steps/trainer.py
+++ b/job/steps/trainer.py
@@ -117,6 +117,8 @@ class Trainer:
         #
         # Until this Spotlight bug is fixed, as a workaround, we split the interactions DataFrame into two
         # DataFrames, one with length L - 2 and one with length 2, then make 2 successive model.fit() calls.
+        #
+        # There's a also a test for this: test_article_recommendations_spotlight_batchsize() in tests/test_helpers.py.
 
         num_interactions = len(training_dataset)  # L
         batch_size = self.params["batch_size"]

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -120,3 +120,26 @@ def test_article_recommendations(external_ids, user_ids, durations, session_date
     embeddings = model.model_embeddings
     distances, nearest_indices = _test_similarities(embeddings, n_recs, decays)
     _test_orders(n_recs, nearest_indices, distances, np.unique(article_ids))
+
+
+def test_article_recommendations_spotlight_batchsize(
+    external_ids, user_ids, durations, session_dates, publish_dates, article_ids, decays
+):
+    """
+    Makes sure that any fix for the Spotlight `squeeze()` bug (see https://github.com/maciejkula/spotlight/issues/107)
+    actually works, i.e., runs smoothly and doesn't return an IndexError.
+    """
+    warehouse_df = pd.DataFrame(
+        {
+            "client_id": user_ids,
+            "external_id": external_ids,
+            "article_id": article_ids,
+            "duration": durations,
+            "published_at": publish_dates,
+            "session_date": session_dates,
+        }
+    )
+    # Set batch_size such that length of dataset % batch_size == 1 to trigger error
+    params = {"model": "IMF", "loss": "adaptive_hinge", "batch_size": len(external_ids) - 1}
+    model = Trainer(warehouse_df, datetime.now().date(), _spotlight_transform, params)
+    model.fit()

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -114,7 +114,6 @@ def test_article_recommendations(external_ids, user_ids, durations, session_date
         }
     )
     params = {"epochs": 35, "embedding_dim": 16, "model": "IMF"}
-    _spotlight_transform(warehouse_df)
     model = Trainer(warehouse_df, datetime.now().date(), _spotlight_transform, params)
     model.fit()
     embeddings = model.model_embeddings


### PR DESCRIPTION
## Description

_This is one of the two proposed workarounds, the other one being #143. If merging this one, close #143._

This PR presents an ~~improved~~ alternative the Spotlight `IndexError` we've been running into and was able to reproduce (see #140 for original error, #143 for the first workaround attempt). 

The reason, it turns out, is a [bug in the Spotlight source code](https://github.com/maciejkula/spotlight/issues/107) that gets triggered if the IMF model's batch size (256, by default) divides the total number of interactions passed to it with a remainder of *exactly* 1, i.e., `num_interactions % batch_size == 1`.

The "fix" is as follows: When we spot an interactions dataset whose length leaves a remainder of 1 when divided by the batch size, we split it into two smaller datasets, neither of whose lengths leaves a remainder of 1. Then we call Spotlight's method to fit the IMF model twice. This is doable because [Spotlight allows multiple `ImplicitFactorizationModel.fit()` calls](https://github.com/maciejkula/spotlight/blob/75f4c8c55090771b52b88ef1a00f75bb39f9f2a9/spotlight/factorization/implicit.py#L188-L190) where each new call starts at the same model state as what's left by the call before it.

Preliminary local runs show calling the fit method twice with two splits performs on par with calling it once with the entire dataset (i.e., no notable change in final loss). If performance becomes an issue in the future, we should take a closer look. For now, because the bug happens very infrequently (all else being equal, the chance of which is around 1 to 256), the splitting process will happen very infrequently.

We can remove this workaround once Spotlight's author fixes the aforementioned bug, although that seems to be unlikely given how inactive the Spotlight repo looks. Finally, we'll also keep the diagnostic code added in #140 for now, should a similar error still appears. If everything looks good after a month or so, we can remove that code.

## Testing
All tests passed. Just like in the original PR, I added a new test, [`test_article_recommendations_spotlight_batchsize()`](https://github.com/LocalAtBrown/article-rec-training-job/blob/e7149cff368369d52cb0e157ffdeed753d358216/tests/test_helpers.py#L124-L144) that attempts to fit the model given `num_interactions % batch_size == 1`. If the "fix" works as expected, no `IndexError` gets raised and the code passes the test.