### PR TITLE
Update site object

### DIFF
--- a/job/steps/collaborative_filtering/fetch_data.py
+++ b/job/steps/collaborative_filtering/fetch_data.py
@@ -15,7 +15,7 @@ from job.helpers.datetime import chunk_name
 from job.steps.collaborative_filtering import warehouse
 from lib.events import Event
 from lib.metrics import Unit, write_metric
-from sites.site import Site, get_bucket_name
+from sites.site import Site
 
 PATH = "/downloads"
 MEM_THRESHOLD = 100000
@@ -32,7 +32,7 @@ def download_chunk(site: Site, dt: datetime.datetime):
     if not os.path.isdir(path):
         os.makedirs(path)
 
-    s3_path = f"s3://{get_bucket_name(site)}/enriched/good/{chunk_name(dt)}"
+    s3_path = f"s3://{site.get_bucket_name()}/enriched/good/{chunk_name(dt)}"
     s3_sync_cmd = f"aws s3 sync {s3_path} {path}".split(" ")
     logging.info(" ".join(s3_sync_cmd))
     return subprocess.Popen(

--- a/sites/philadelphia_inquirer.py
+++ b/sites/philadelphia_inquirer.py
@@ -2,6 +2,7 @@ import logging
 from datetime import date, datetime
 from typing import Any, Dict, List, Optional, Union
 
+import pandas as pd
 from requests.models import Response
 
 from lib.config import config
@@ -15,7 +16,7 @@ from sites.helpers import (
     validate_response,
     validate_status_code,
 )
-from sites.site import Site
+from sites.site import NewSite
 
 """
 ARC API documentation
@@ -48,223 +49,221 @@ SCRAPE_CONFIG = {
     "requests_per_second": 4,
 }
 
-
-def bulk_fetch(start_date: date, end_date: date) -> List[Dict[str, Any]]:
-    logging.info(f"Fetching articles from {start_date} to {end_date}")
-    start_dt = datetime.combine(start_date, datetime.min.time())
-    end_dt = datetime.combine(end_date, datetime.min.time())
-    start_ts = ms_timestamp(start_dt)
-    end_ts = ms_timestamp(end_dt)
-    params = {
-        "q": f"publish_date:[{start_ts} TO {end_ts}]",
-        "include_distributor_category": "staff",
-        "_sourceInclude": "headlines,publish_date,_id,canonical_url",
-        "website": API_SITE,
-        "size": 100,  # inquirer publishes ~50 articles per day
-    }
-    res = safe_get(f"{API_URL}/search/published", API_HEADER, params, SCRAPE_CONFIG)
-    json_res = res.json()
-    metadata = [parse_article_metadata(a, a["_id"], a["canonical_url"]) for a in json_res["content_elements"]]
-    return metadata
-
-
 INVALID_PREFIXES = ["/author", "/wires", "/zzz-systest"]
 
 
-def extract_external_id(path: str) -> Optional[str]:
-    """Request content ID from a url from ARC API
+class PhiladelphiaInquirer(NewSite):
+    def transform_raw_data(self, df: pd.DataFrame) -> pd.DataFrame:
+        return transform_data_google_tag_manager(df=df)
 
-    :path:an Inquirer url
-    :return contentID: Unique ID of url
-    """
-    params = {
-        "website_url": path,
-        "published": "true",
-        "website": API_SITE,
-        "included_fields": "_id,source,taxonomy",
-    }
+    def extract_external_id(self, path: str) -> Optional[str]:
+        """Request content ID from a url from ARC API
 
-    for prefix in INVALID_PREFIXES:
-        if path.startswith(prefix):
+        :path:an Inquirer url
+        :return contentID: Unique ID of url
+        """
+        params = {
+            "website_url": path,
+            "published": "true",
+            "website": API_SITE,
+            "included_fields": "_id,source,taxonomy",
+        }
+
+        for prefix in INVALID_PREFIXES:
+            if path.startswith(prefix):
+                raise ArticleScrapingError(
+                    ScrapeFailure.FAILED_SITE_VALIDATION,
+                    path,
+                    external_id=None,
+                    msg="Skipping path with invalid prefix",
+                )
+
+        try:
+            res = safe_get(API_URL, API_HEADER, params, self.scrape_config)
+            res = res.json()
+        except Exception as e:
             raise ArticleScrapingError(
-                ScrapeFailure.FAILED_SITE_VALIDATION,
-                path,
-                external_id=None,
-                msg="Skipping path with invalid prefix",
+                ScrapeFailure.FETCH_ERROR, path, external_id=None, msg="ARC API request failed"
+            ) from e
+
+        if "_id" not in res:
+            raise ArticleScrapingError(
+                ScrapeFailure.NO_EXTERNAL_ID, path, external_id=None, msg="External ID not detected in response"
             )
 
-    try:
-        res = safe_get(API_URL, API_HEADER, params, SCRAPE_CONFIG)
-        res = res.json()
-    except Exception as e:
-        raise ArticleScrapingError(ScrapeFailure.FETCH_ERROR, path, external_id=None, msg="ARC API request failed") from e
+        external_id = res["_id"]
 
-    if "_id" not in res:
-        raise ArticleScrapingError(
-            ScrapeFailure.NO_EXTERNAL_ID, path, external_id=None, msg="External ID not detected in response"
-        )
+        IN_HOUSE_PLATFORMS = {"composer", "ellipsis"}
+        if res.get("source", {}).get("system") not in IN_HOUSE_PLATFORMS:
+            raise ArticleScrapingError(
+                ScrapeFailure.FAILED_SITE_VALIDATION, path, str(external_id), "Not in-house article"
+            )
 
-    external_id = res["_id"]
+        TEST_SITE = "/zzz-systest"
+        sites = res.get("taxonomy", {}).get("sites", [])
+        if sites and sites[0].get("_id") == TEST_SITE:
+            raise ArticleScrapingError(ScrapeFailure.FAILED_SITE_VALIDATION, path, str(external_id), "Test article")
 
-    IN_HOUSE_PLATFORMS = {"composer", "ellipsis"}
-    if res.get("source", {}).get("system") not in IN_HOUSE_PLATFORMS:
-        raise ArticleScrapingError(ScrapeFailure.FAILED_SITE_VALIDATION, path, str(external_id), "Not in-house article")
+        return external_id
 
-    TEST_SITE = "/zzz-systest"
-    sites = res.get("taxonomy", {}).get("sites", [])
-    if sites and sites[0].get("_id") == TEST_SITE:
-        raise ArticleScrapingError(ScrapeFailure.FAILED_SITE_VALIDATION, path, str(external_id), "Test article")
+    def scrape_article_metadata(self, page: Union[Response, dict], external_id: str, path: str) -> dict:
+        """ARC API JSON parser
 
-    return external_id
+        :page: JSON Payload from ARC for an external_id
+        :external_id: Unique identifier for URL
+        :return: Relevant metadata from an API response
+        """
 
+        metadata = {}
+        parse_keys = [
+            ("title", self.get_headline),
+            ("path", self.get_path),
+            ("published_at", self.get_date),
+            ("external_id", self.get_external_id),
+        ]
 
-def try_parsing_date(text: str, formats: List[str]) -> datetime:
-    for fmt in formats:
+        if isinstance(page, dict):
+            res = page
+        else:
+            res = page.json()
+
+        for prop, func in parse_keys:
+            val = None
+            try:
+                val = func(res)
+            except Exception as e:
+                raise ArticleScrapingError(ScrapeFailure.FETCH_ERROR, path, external_id, f"Error parsing {prop}") from e
+            metadata[prop] = val
+
+        return metadata
+
+    def fetch_article(self, external_id: str, path: str) -> Response:
+        """Fetch and validate article from the ARC API
+
+        :external_id: Unique identifier for a URL
+        :return: API response
+        :throws: ArticleScrapingError
+        """
+        params = {
+            "_id": external_id,
+            "website": API_SITE,
+            "published": "true",
+            "included_fields": "headlines,publish_date,_id,canonical_url",
+        }
+
         try:
-            return datetime.strptime(text, fmt)
-        except ValueError:
-            pass
-    raise ValueError("no valid date format found")
-
-
-def get_date(res_val: dict) -> str:
-    """ARC response date parser. PI response includes timezone
-
-    :res_val: JSON payload from ARC API
-    :return: Isoformat date string
-    """
-    formats = [
-        "%Y-%m-%dT%H:%M:%SZ",  # 2021-12-01T15:53:20Z
-        "%Y-%m-%dT%H:%M:%S.%fZ",  # 2021-11-17T00:44:12.319Z
-    ]
-    dt = try_parsing_date(res_val["publish_date"], formats)
-    return dt.isoformat()
-
-
-def get_path(res_val: dict) -> str:
-    """ARC response canonical path parser
-
-    :res_val: JSON payload from ARC API
-    :return: Canonical URL Path for external_ID
-    E.g.,: /news/philadelphia-mayor-jim-kenney-johnny-doc-bobby-henon-convicted-20211116.html
-    """
-    return res_val["canonical_url"]
-
-
-def get_headline(res_val: dict) -> str:
-    """ARC response headline parser
-
-    :res_val: JSON payload from ARC API
-    :return: meta_title (if available) or basic title
-    """
-    res_val = res_val["headlines"]
-
-    return res_val.get("meta_title") or res_val["basic"]
-
-
-def get_external_id(res_val: dict) -> str:
-    external_id = res_val["_id"]
-    return external_id
-
-
-def parse_article_metadata(page: Union[Response, dict], external_id: str, path: str) -> dict:
-    """ARC API JSON parser
-
-    :page: JSON Payload from ARC for an external_id
-    :external_id: Unique identifier for URL
-    :return: Relevant metadata from an API response
-    """
-
-    metadata = {}
-    parse_keys = [
-        ("title", get_headline),
-        ("path", get_path),
-        ("published_at", get_date),
-        ("external_id", get_external_id),
-    ]
-
-    if isinstance(page, dict):
-        res = page
-    else:
-        res = page.json()
-
-    for prop, func in parse_keys:
-        val = None
-        try:
-            val = func(res)
+            res = safe_get(API_URL, API_HEADER, params, self.scrape_config)
         except Exception as e:
-            raise ArticleScrapingError(ScrapeFailure.FETCH_ERROR, path, external_id, f"Error parsing {prop}") from e
-        metadata[prop] = val
+            raise ArticleScrapingError(
+                ScrapeFailure.FETCH_ERROR, path, external_id, f"Error fetching article URL: {API_URL}"
+            ) from e
 
-    return metadata
+        error_msg = validate_response(res, [validate_status_code, self.validate_attributes])
+        if error_msg:
+            raise ArticleScrapingError(ScrapeFailure.MALFORMED_RESPONSE, path, external_id, error_msg)
+
+        return res
+
+    def bulk_fetch(self, start_date: date, end_date: date) -> List[Dict[str, Any]]:
+        logging.info(f"Fetching articles from {start_date} to {end_date}")
+        start_dt = datetime.combine(start_date, datetime.min.time())
+        end_dt = datetime.combine(end_date, datetime.min.time())
+        start_ts = ms_timestamp(start_dt)
+        end_ts = ms_timestamp(end_dt)
+        params = {
+            "q": f"publish_date:[{start_ts} TO {end_ts}]",
+            "include_distributor_category": "staff",
+            "_sourceInclude": "headlines,publish_date,_id,canonical_url",
+            "website": API_SITE,
+            "size": 100,  # inquirer publishes ~50 articles per day
+        }
+        res = safe_get(f"{API_URL}/search/published", API_HEADER, params, self.scrape_config)
+        json_res = res.json()
+        metadata = [self.scrape_article_metadata(a, a["_id"], a["canonical_url"]) for a in json_res["content_elements"]]
+        return metadata
+
+    def get_date(self, res_val: dict) -> str:
+        """ARC response date parser. PI response includes timezone
+
+        :res_val: JSON payload from ARC API
+        :return: Isoformat date string
+        """
+        formats = [
+            "%Y-%m-%dT%H:%M:%SZ",  # 2021-12-01T15:53:20Z
+            "%Y-%m-%dT%H:%M:%S.%fZ",  # 2021-11-17T00:44:12.319Z
+        ]
+        dt = self.try_parsing_date(res_val["publish_date"], formats)
+        return dt.isoformat()
+
+    @staticmethod
+    def validate_attributes(res: Response) -> Optional[str]:
+        """ARC API response validator
+
+        :res: ARC API JSON response payload
+        :return: None if no errors; otherwise string describing validation issue
+        """
+        try:
+            content = res.json()
+        except Exception as e:
+            return f"Cannot parse article response JSON: {e}"
+
+        if "headlines" not in content or ("headlines" in content and "basic" not in content["headlines"]):
+            return "Article missing headline"
+
+        if "canonical_url" not in content:
+            return "Article canonical URL missing"
+
+        if "publish_date" not in content:
+            return "Article publish date missing"
+
+        try:
+            datetime.strptime(content["publish_date"], "%Y-%m-%dT%H:%M:%S.%fZ").isoformat()
+        except Exception as e:
+            return f"Cannot parse date of publication: {e}"
+
+        return None
+
+    @staticmethod
+    def try_parsing_date(text: str, formats: List[str]) -> datetime:
+        for fmt in formats:
+            try:
+                return datetime.strptime(text, fmt)
+            except ValueError:
+                pass
+        raise ValueError("no valid date format found")
+
+    @staticmethod
+    def get_path(res_val: dict) -> str:
+        """ARC response canonical path parser
+
+        :res_val: JSON payload from ARC API
+        :return: Canonical URL Path for external_ID
+        E.g.,: /news/philadelphia-mayor-jim-kenney-johnny-doc-bobby-henon-convicted-20211116.html
+        """
+        return res_val["canonical_url"]
+
+    @staticmethod
+    def get_headline(res_val: dict) -> str:
+        """ARC response headline parser
+
+        :res_val: JSON payload from ARC API
+        :return: meta_title (if available) or basic title
+        """
+        res_val = res_val["headlines"]
+
+        return res_val.get("meta_title") or res_val["basic"]
+
+    @staticmethod
+    def get_external_id(res_val: dict) -> str:
+        external_id = res_val["_id"]
+        return external_id
 
 
-def validate_attributes(res: Response) -> Optional[str]:
-    """ARC API response validator
-
-    :res: ARC API JSON response payload
-    :return: None if no errors; otherwise string describing validation issue
-    """
-    try:
-        content = res.json()
-    except Exception as e:
-        return f"Cannot parse article response JSON: {e}"
-
-    if "headlines" not in content or ("headlines" in content and "basic" not in content["headlines"]):
-        return "Article missing headline"
-
-    if "canonical_url" not in content:
-        return "Article canonical URL missing"
-
-    if "publish_date" not in content:
-        return "Article publish date missing"
-
-    try:
-        datetime.strptime(content["publish_date"], "%Y-%m-%dT%H:%M:%S.%fZ").isoformat()
-    except Exception as e:
-        return f"Cannot parse date of publication: {e}"
-
-    return None
-
-
-def fetch_article(external_id: str, path: str) -> Response:
-    """Fetch and validate article from the ARC API
-
-    :external_id: Unique identifier for a URL
-    :return: API response
-    :throws: ArticleScrapingError
-    """
-    params = {
-        "_id": external_id,
-        "website": API_SITE,
-        "published": "true",
-        "included_fields": "headlines,publish_date,_id,canonical_url",
-    }
-
-    try:
-        res = safe_get(API_URL, API_HEADER, params, SCRAPE_CONFIG)
-    except Exception as e:
-        raise ArticleScrapingError(
-            ScrapeFailure.FETCH_ERROR, path, external_id, f"Error fetching article URL: {API_URL}"
-        ) from e
-
-    error_msg = validate_response(res, [validate_status_code, validate_attributes])
-    if error_msg:
-        raise ArticleScrapingError(ScrapeFailure.MALFORMED_RESPONSE, path, external_id, error_msg)
-
-    return res
-
-
-PI_SITE = Site(
-    NAME,
-    FIELDS,
-    TRAINING_PARAMS,
-    SCRAPE_CONFIG,
-    transform_data_google_tag_manager,
-    extract_external_id,
-    parse_article_metadata,
-    fetch_article,
-    bulk_fetch,
-    POPULARITY_WINDOW,
-    MAX_ARTICLE_AGE,
+PI_SITE = NewSite(
+    name=NAME,
+    fields=FIELDS,
+    training_params=TRAINING_PARAMS,
+    scrape_config=SCRAPE_CONFIG,
+    popularity_window=POPULARITY_WINDOW,
+    max_article_age=MAX_ARTICLE_AGE,
 )

--- a/sites/philadelphia_inquirer.py
+++ b/sites/philadelphia_inquirer.py
@@ -16,7 +16,7 @@ from sites.helpers import (
     validate_response,
     validate_status_code,
 )
-from sites.site import NewSite
+from sites.site import Site
 
 """
 ARC API documentation
@@ -52,7 +52,7 @@ SCRAPE_CONFIG = {
 INVALID_PREFIXES = ["/author", "/wires", "/zzz-systest"]
 
 
-class PhiladelphiaInquirer(NewSite):
+class PhiladelphiaInquirer(Site):
     def transform_raw_data(self, df: pd.DataFrame) -> pd.DataFrame:
         return transform_data_google_tag_manager(df=df)
 
@@ -259,7 +259,7 @@ class PhiladelphiaInquirer(NewSite):
         return external_id
 
 
-PI_SITE = NewSite(
+PI_SITE = PhiladelphiaInquirer(
     name=NAME,
     fields=FIELDS,
     training_params=TRAINING_PARAMS,

--- a/sites/philadelphia_inquirer.py
+++ b/sites/philadelphia_inquirer.py
@@ -53,9 +53,6 @@ INVALID_PREFIXES = ["/author", "/wires", "/zzz-systest"]
 
 
 class PhiladelphiaInquirer(Site):
-    def transform_raw_data(self, df: pd.DataFrame) -> pd.DataFrame:
-        return transform_data_google_tag_manager(df=df)
-
     def extract_external_id(self, path: str) -> Optional[str]:
         """Request content ID from a url from ARC API
 
@@ -198,6 +195,10 @@ class PhiladelphiaInquirer(Site):
     def bulk_fetch_by_external_id(self, external_ids) -> None:
         # https://stackoverflow.com/questions/16706956/is-there-a-difference-between-raise-exception-and-raise-exception-without
         raise NotImplementedError
+
+    @staticmethod
+    def transform_raw_data(df: pd.DataFrame) -> pd.DataFrame:
+        return transform_data_google_tag_manager(df=df)
 
     @staticmethod
     def get_article_text(metadata: Dict[str, Any]) -> None:

--- a/sites/singleton.py
+++ b/sites/singleton.py
@@ -1,3 +1,4 @@
+import logging
 from abc import ABCMeta
 
 
@@ -16,4 +17,6 @@ class SingletonABCMeta(ABCMeta):
     def __call__(cls, *args, **kwargs):
         if cls not in cls._instances:
             cls._instances[cls] = super(SingletonABCMeta, cls).__call__(*args, **kwargs)
+        else:
+            logging.warning(f"You tried to instantiate an instance of {cls.__name__} but one already exists.")
         return cls._instances[cls]

--- a/sites/singleton.py
+++ b/sites/singleton.py
@@ -10,6 +10,8 @@ class SingletonABCMeta(ABCMeta):
     And stackoverflow: https://stackoverflow.com/questions/6760685/creating-a-singleton-in-python
     Inheriting from `ABCMeta` ensures behavior of both a singleton, defined here, and an abstract base
     class, defined by `ABCMeta`.
+
+    For why we decided to use the singleton pattern here, visit https://github.com/LocalAtBrown/article-rec-training-job/pull/149#discussion_r968885680
     """
 
     _instances = {}

--- a/sites/singleton.py
+++ b/sites/singleton.py
@@ -1,0 +1,14 @@
+class Singleton(type):
+    """
+    A singleton definition to be used as a metaclass.
+    A singleton pattern as defined here is where a class only ever has ONE instantiation of it.
+    Here is a helpful wikipedia link: https://en.wikipedia.org/wiki/Singleton_pattern
+    And stackoverflow: https://stackoverflow.com/questions/6760685/creating-a-singleton-in-python
+    """
+
+    _instances = {}
+
+    def __call__(cls, *args, **kwargs):
+        if cls not in cls._instances:
+            cls._instances[cls] = super(Singleton, cls).__call__(*args, **kwargs)
+        return cls._instances[cls]

--- a/sites/singleton.py
+++ b/sites/singleton.py
@@ -1,14 +1,19 @@
-class Singleton(type):
+from abc import ABCMeta
+
+
+class SingletonABCMeta(ABCMeta):
     """
     A singleton definition to be used as a metaclass.
     A singleton pattern as defined here is where a class only ever has ONE instantiation of it.
     Here is a helpful wikipedia link: https://en.wikipedia.org/wiki/Singleton_pattern
     And stackoverflow: https://stackoverflow.com/questions/6760685/creating-a-singleton-in-python
+    Inheriting from `ABCMeta` ensures behavior of both a singleton, defined here, and an abstract base
+    class, defined by `ABCMeta`.
     """
 
     _instances = {}
 
     def __call__(cls, *args, **kwargs):
         if cls not in cls._instances:
-            cls._instances[cls] = super(Singleton, cls).__call__(*args, **kwargs)
+            cls._instances[cls] = super(SingletonABCMeta, cls).__call__(*args, **kwargs)
         return cls._instances[cls]

--- a/sites/site.py
+++ b/sites/site.py
@@ -1,5 +1,4 @@
 from abc import abstractmethod
-from collections import namedtuple
 from dataclasses import dataclass
 from datetime import date
 from typing import Any, Dict, List, Optional, Set, Union
@@ -9,32 +8,34 @@ from requests.models import Response
 
 from sites.singleton import SingletonABCMeta
 
-Site = namedtuple(
-    "Site",
-    [
-        "name",  # property, string
-        "fields",  # property, dict
-        "training_params",  # property, dict (class candidate)
-        "scrape_config",  # property, dict (class candidate)
-        "transform_raw_data",  # function, (df) -> df
-        "extract_external_id",  # function, (path: str) -> optional(str)
-        "scrape_article_metadata",  # function, (page, id, path) -> dict
-        "fetch_article",  # function, (id, path) -> response
-        "bulk_fetch",  # (start_date, end_date) -> list[dict[str???]]
-        "popularity_window",  # property, int
-        "max_article_age",  # property, int
-    ],
-)
+# Site = namedtuple(
+#     "Site",
+#     [
+#         "name",  # property, string
+#         "fields",  # property, dict
+#         "training_params",  # property, dict (class candidate)
+#         "scrape_config",  # property, dict (class candidate)
+#         "transform_raw_data",  # function, (df) -> df
+#         "extract_external_id",  # function, (path: str) -> optional(str)
+#         "scrape_article_metadata",  # function, (page, id, path) -> dict
+#         "fetch_article",  # function, (id, path) -> response
+#         "bulk_fetch",  # (start_date, end_date) -> list[dict[str???]]
+#         "popularity_window",  # property, int
+#         "max_article_age",  # property, int
+#     ],
+# )
 
 
 @dataclass
-class NewSite(metaclass=SingletonABCMeta):
+class Site(metaclass=SingletonABCMeta):
     name: str
     fields: Set[str]  # needs better name
     training_params: dict  # should define with more specifics unless it needs to be flexible
     scrape_config: dict  # should define with more specifics unless it needs to be flexible
-    popularity_window: int  # what does this mean to a human? days?
-    max_article_age: int  # what does this mean to a human? days?
+    # this is a number of days; will only recommend articles within the past X days
+    popularity_window: int
+    # this is a number of years; will grab dwell time data for any article within the past X years
+    max_article_age: int
 
     def get_bucket_name(self):
         return f"lnl-snowplow-{self.name}"

--- a/sites/site.py
+++ b/sites/site.py
@@ -8,23 +8,6 @@ from requests.models import Response
 
 from sites.singleton import SingletonABCMeta
 
-# Site = namedtuple(
-#     "Site",
-#     [
-#         "name",  # property, string
-#         "fields",  # property, dict
-#         "training_params",  # property, dict (class candidate)
-#         "scrape_config",  # property, dict (class candidate)
-#         "transform_raw_data",  # function, (df) -> df
-#         "extract_external_id",  # function, (path: str) -> optional(str)
-#         "scrape_article_metadata",  # function, (page, id, path) -> dict
-#         "fetch_article",  # function, (id, path) -> response
-#         "bulk_fetch",  # (start_date, end_date) -> list[dict[str???]]
-#         "popularity_window",  # property, int
-#         "max_article_age",  # property, int
-#     ],
-# )
-
 
 @dataclass
 class Site(metaclass=SingletonABCMeta):

--- a/sites/site.py
+++ b/sites/site.py
@@ -2,7 +2,7 @@ from abc import abstractmethod
 from collections import namedtuple
 from dataclasses import dataclass
 from datetime import date
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Set, Union
 
 import pandas as pd
 from requests.models import Response
@@ -30,7 +30,7 @@ Site = namedtuple(
 @dataclass
 class NewSite(metaclass=SingletonABCMeta):
     name: str
-    fields: dict  # needs better name
+    fields: Set[str]  # needs better name
     training_params: dict  # should define with more specifics unless it needs to be flexible
     scrape_config: dict  # should define with more specifics unless it needs to be flexible
     popularity_window: int  # what does this mean to a human? days?

--- a/sites/site.py
+++ b/sites/site.py
@@ -1,6 +1,11 @@
 from abc import ABC, abstractmethod
 from collections import namedtuple
 from dataclasses import dataclass
+from datetime import date
+from typing import Any, Dict, List, Optional, Union
+
+import pandas as pd
+from requests.models import Response
 
 Site = namedtuple(
     "Site",
@@ -33,23 +38,23 @@ class NewSite(ABC):
         return f"lnl-snowplow-{self.name}"
 
     @abstractmethod
-    def transform_raw_data(self):
+    def transform_raw_data(self, df: pd.DataFrame) -> pd.DataFrame:
         pass
 
     @abstractmethod
-    def extract_external_id(self):
+    def extract_external_id(self, path: str) -> Optional[str]:
         pass
 
     @abstractmethod
-    def scrape_article_metadata(self):
+    def scrape_article_metadata(self, page: Union[Response, dict], external_id: str, path: str) -> dict:
         pass
 
     @abstractmethod
-    def fetch_article(self):
+    def fetch_article(self, external_id: str, path: str) -> Response:
         pass
 
     @abstractmethod
-    def bulk_fetch(self):
+    def bulk_fetch(self, start_date: date, end_date: date) -> List[Dict[str, Any]]:
         pass
 
 

--- a/sites/site.py
+++ b/sites/site.py
@@ -1,4 +1,4 @@
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 from collections import namedtuple
 from dataclasses import dataclass
 from datetime import date
@@ -6,6 +6,8 @@ from typing import Any, Dict, List, Optional, Union
 
 import pandas as pd
 from requests.models import Response
+
+from sites.singleton import SingletonABCMeta
 
 Site = namedtuple(
     "Site",
@@ -26,7 +28,7 @@ Site = namedtuple(
 
 
 @dataclass
-class NewSite(ABC):
+class NewSite(metaclass=SingletonABCMeta):
     name: str
     fields: dict  # needs better name
     training_params: dict  # should define with more specifics unless it needs to be flexible

--- a/sites/site.py
+++ b/sites/site.py
@@ -24,10 +24,6 @@ class Site(metaclass=SingletonABCMeta):
         return f"lnl-snowplow-{self.name}"
 
     @abstractmethod
-    def transform_raw_data(self, df: pd.DataFrame) -> pd.DataFrame:
-        pass
-
-    @abstractmethod
     def extract_external_id(self, path: str) -> Optional[str]:
         pass
 
@@ -45,6 +41,11 @@ class Site(metaclass=SingletonABCMeta):
 
     @abstractmethod
     def bulk_fetch_by_external_id(self, external_ids: List[str]) -> List[Dict[str, Any]]:
+        pass
+
+    @staticmethod
+    @abstractmethod
+    def transform_raw_data(df: pd.DataFrame) -> pd.DataFrame:
         pass
 
     @staticmethod

--- a/sites/site.py
+++ b/sites/site.py
@@ -1,21 +1,56 @@
+from abc import ABC, abstractmethod
 from collections import namedtuple
+from dataclasses import dataclass
 
 Site = namedtuple(
     "Site",
     [
-        "name",
-        "fields",
-        "training_params",
-        "scrape_config",
-        "transform_raw_data",
-        "extract_external_id",
-        "scrape_article_metadata",
-        "fetch_article",
-        "bulk_fetch",
-        "popularity_window",
-        "max_article_age",
+        "name",  # property, string
+        "fields",  # property, dict
+        "training_params",  # property, dict (class candidate)
+        "scrape_config",  # property, dict (class candidate)
+        "transform_raw_data",  # function, (df) -> df
+        "extract_external_id",  # function, (path: str) -> optional(str)
+        "scrape_article_metadata",  # function, (page, id, path) -> dict
+        "fetch_article",  # function, (id, path) -> response
+        "bulk_fetch",  # (start_date, end_date) -> list[dict[str???]]
+        "popularity_window",  # property, int
+        "max_article_age",  # property, int
     ],
 )
+
+
+@dataclass
+class NewSite(ABC):
+    name: str
+    fields: dict  # needs better name
+    training_params: dict  # should define with more specifics unless it needs to be flexible
+    scrape_config: dict  # should define with more specifics unless it needs to be flexible
+    popularity_window: int  # what does this mean to a human? days?
+    max_article_age: int  # what does this mean to a human? days?
+
+    def get_bucket_name(self):
+        return f"lnl-snowplow-{self.name}"
+
+    @abstractmethod
+    def transform_raw_data(self):
+        pass
+
+    @abstractmethod
+    def extract_external_id(self):
+        pass
+
+    @abstractmethod
+    def scrape_article_metadata(self):
+        pass
+
+    @abstractmethod
+    def fetch_article(self):
+        pass
+
+    @abstractmethod
+    def bulk_fetch(self):
+        pass
 
 
 def get_bucket_name(site: Site):

--- a/sites/site.py
+++ b/sites/site.py
@@ -51,7 +51,3 @@ class Site(metaclass=SingletonABCMeta):
     @abstractmethod
     def get_article_text(metadata: Dict[str, Any]) -> str:
         pass
-
-
-def get_bucket_name(site: Site):
-    return f"lnl-snowplow-{site.name}"

--- a/sites/texas_tribune.py
+++ b/sites/texas_tribune.py
@@ -216,7 +216,7 @@ TT_SITE = Site(
 
 class TexasTribune(NewSite):
     def transform_raw_data(self, df: pd.DataFrame) -> pd.DataFrame:
-        pass
+        return transform_data_google_tag_manager(df=df)
 
     def extract_external_id(self, path: str) -> Optional[str]:
         pass

--- a/sites/texas_tribune.py
+++ b/sites/texas_tribune.py
@@ -75,9 +75,6 @@ NON_ARTICLE_PREFIXES = [
 
 
 class TexasTribune(Site):
-    def transform_raw_data(self, df: pd.DataFrame) -> pd.DataFrame:
-        return transform_data_google_tag_manager(df=df)
-
     def extract_external_id(self, path: str) -> Optional[str]:
         for prefix in NON_ARTICLE_PREFIXES:
             if path.startswith(prefix):
@@ -224,6 +221,10 @@ class TexasTribune(Site):
                 logging.info(f"Fetched {len(data)}/{num_articles} articles")
 
         return data
+
+    @staticmethod
+    def transform_raw_data(df: pd.DataFrame) -> pd.DataFrame:
+        return transform_data_google_tag_manager(df=df)
 
     @staticmethod
     def get_title(res: dict) -> str:

--- a/sites/texas_tribune.py
+++ b/sites/texas_tribune.py
@@ -260,7 +260,22 @@ class TexasTribune(NewSite):
         return metadata
 
     def fetch_article(self, external_id: str, path: str) -> Response:
-        pass
+        external_id = int(external_id)  # type: ignore
+
+        api_url = f"https://{DOMAIN}/api/v2/articles/{external_id}"
+
+        try:
+            res = safe_get(api_url, scrape_config=SCRAPE_CONFIG)
+        except Exception as e:
+            raise ArticleScrapingError(
+                ScrapeFailure.FETCH_ERROR, path, external_id, f"Error fetching article url: {api_url}"
+            ) from e
+
+        error_msg = validate_response(res, [validate_status_code])
+        if error_msg is not None:
+            raise ArticleScrapingError(ScrapeFailure.FAILED_SITE_VALIDATION, path, str(external_id), error_msg)
+
+        return res
 
     def bulk_fetch(self, start_date: date, end_date: date) -> List[Dict[str, Any]]:
         pass

--- a/sites/texas_tribune.py
+++ b/sites/texas_tribune.py
@@ -278,7 +278,21 @@ class TexasTribune(NewSite):
         return res
 
     def bulk_fetch(self, start_date: date, end_date: date) -> List[Dict[str, Any]]:
-        pass
+        logging.info(f"Fetching articles from {start_date} to {end_date}")
+
+        API_URL = f"https://{DOMAIN}/api/v2/articles"
+        DATE_FORMAT = "%Y-%m-%dT%H:%M:%S"
+        # texas tribune publishes 5-10 articles per day
+        params = {
+            "start_date": start_date.strftime(DATE_FORMAT),
+            "end_date": end_date.strftime(DATE_FORMAT),
+            "limit": 100,
+        }
+        res = safe_get(API_URL, params=params, scrape_config=SCRAPE_CONFIG)
+        json_res = res.json()
+
+        metadata = [parse_metadata(article) for article in json_res["results"]]
+        return metadata
 
 
 NEW_TT_SITE = TexasTribune(

--- a/sites/texas_tribune.py
+++ b/sites/texas_tribune.py
@@ -252,7 +252,12 @@ class TexasTribune(NewSite):
             )
 
     def scrape_article_metadata(self, page: Union[Response, dict], external_id: str, path: str) -> dict:
-        pass
+        try:
+            api_info = page.json()
+        except Exception as e:
+            raise ArticleScrapingError(ScrapeFailure.FETCH_ERROR, path, external_id, "Response JSON parse failed") from e
+        metadata = parse_metadata(api_info, external_id, path)
+        return metadata
 
     def fetch_article(self, external_id: str, path: str) -> Response:
         pass

--- a/sites/texas_tribune.py
+++ b/sites/texas_tribune.py
@@ -17,7 +17,7 @@ from sites.helpers import (
     validate_response,
     validate_status_code,
 )
-from sites.site import NewSite, Site
+from sites.site import NewSite
 
 """
 TT API documentation
@@ -71,149 +71,6 @@ NON_ARTICLE_PREFIXES = [
 ]
 
 
-def bulk_fetch(start_date: date, end_date: date) -> List[Dict[str, Any]]:
-    logging.info(f"Fetching articles from {start_date} to {end_date}")
-
-    API_URL = f"https://{DOMAIN}/api/v2/articles"
-    DATE_FORMAT = "%Y-%m-%dT%H:%M:%S"
-    # texas tribune publishes 5-10 articles per day
-    params = {"start_date": start_date.strftime(DATE_FORMAT), "end_date": end_date.strftime(DATE_FORMAT), "limit": 100}
-    res = safe_get(API_URL, params=params, scrape_config=SCRAPE_CONFIG)
-    json_res = res.json()
-
-    metadata = [parse_metadata(article) for article in json_res["results"]]
-    return metadata
-
-
-def extract_external_id(path: str) -> str:
-    for prefix in NON_ARTICLE_PREFIXES:
-        if path.startswith(prefix):
-            raise ArticleScrapingError(
-                ScrapeFailure.NO_EXTERNAL_ID, path, external_id=None, msg="Skipping non-article path"
-            )
-
-    article_url = f"https://{DOMAIN}{path}"
-    try:
-        page = safe_get(article_url, scrape_config=SCRAPE_CONFIG)
-    except Exception as e:
-        raise ArticleScrapingError(
-            ScrapeFailure.FETCH_ERROR,
-            path,
-            external_id=None,
-            msg=f"API request failed for {article_url}",
-        ) from e
-    soup = BeautifulSoup(page.text, features="html.parser")
-
-    token = None
-    html_content = soup.html
-    matched = re.search(r"contentID: '\d+'", str(html_content))
-    if matched and matched.group(0):
-        token = matched.group(0)
-        contentID = token.split("'")[1]
-        return str(int(contentID))
-    else:
-        raise ArticleScrapingError(
-            ScrapeFailure.NO_EXTERNAL_ID,
-            path,
-            external_id=None,
-            msg="External ID not found",
-        )
-
-
-def get_title(res: dict) -> str:
-    title = res["headline"]
-    return title
-
-
-def get_published_at(res: dict) -> str:
-    # example published_at: '2021-11-12T12:45:35-06:00'
-    pub_date = res["pub_date"]
-    return pub_date
-
-
-def get_path(page: dict) -> str:
-    # there are times when older articles redirect to an alternate path, for ex:
-    # https://washingtoncitypaper.com/food/article/20830693/awardwinning-chef-michel-richard-dies-at-age-68
-    return urlparse(page["url"]).path
-
-
-def get_external_id(page: dict) -> str:
-    external_id = page["id"]
-    return external_id
-
-
-def parse_metadata(
-    api_info: Dict[str, Any], external_id: Optional[str] = None, path: Optional[str] = None
-) -> Dict[str, Any]:
-    metadata = {}
-    parsers = [
-        ("title", get_title),
-        ("published_at", get_published_at),
-        ("path", get_path),
-        ("external_id", get_external_id),
-    ]
-    for prop, func in parsers:
-        try:
-            val = func(api_info)
-        except Exception as e:
-            if not external_id:
-                external_id = "no_id_obtained"
-            if not path:
-                path = "no_path_obtained"
-            raise ArticleScrapingError(
-                ScrapeFailure.MALFORMED_RESPONSE, external_id, path, "Error parsing metadata for article"
-            ) from e
-        metadata[prop] = val
-
-    return metadata
-
-
-def scrape_article_metadata(page: Response, external_id: str, path: str) -> dict:
-    try:
-        api_info = page.json()
-    except Exception as e:
-        raise ArticleScrapingError(ScrapeFailure.FETCH_ERROR, path, external_id, "Response JSON parse failed") from e
-    metadata = parse_metadata(api_info, external_id, path)
-    return metadata
-
-
-def fetch_article(
-    external_id: str,
-    path: str,
-) -> Response:
-    external_id = int(external_id)  # type: ignore
-
-    api_url = f"https://{DOMAIN}/api/v2/articles/{external_id}"
-
-    try:
-        res = safe_get(api_url, scrape_config=SCRAPE_CONFIG)
-    except Exception as e:
-        raise ArticleScrapingError(
-            ScrapeFailure.FETCH_ERROR, path, external_id, f"Error fetching article url: {api_url}"
-        ) from e
-
-    error_msg = validate_response(res, [validate_status_code])
-    if error_msg is not None:
-        raise ArticleScrapingError(ScrapeFailure.FAILED_SITE_VALIDATION, path, str(external_id), error_msg)
-
-    return res
-
-
-TT_SITE = Site(
-    NAME,
-    FIELDS,
-    TRAINING_PARAMS,
-    SCRAPE_CONFIG,
-    transform_data_google_tag_manager,
-    extract_external_id,
-    scrape_article_metadata,
-    fetch_article,
-    bulk_fetch,
-    POPULARITY_WINDOW,
-    MAX_ARTICLE_AGE,
-)
-
-
 class TexasTribune(NewSite):
     def transform_raw_data(self, df: pd.DataFrame) -> pd.DataFrame:
         return transform_data_google_tag_manager(df=df)
@@ -256,7 +113,7 @@ class TexasTribune(NewSite):
             api_info = page.json()
         except Exception as e:
             raise ArticleScrapingError(ScrapeFailure.FETCH_ERROR, path, external_id, "Response JSON parse failed") from e
-        metadata = parse_metadata(api_info, external_id, path)
+        metadata = self.parse_metadata(api_info, external_id, path)
         return metadata
 
     def fetch_article(self, external_id: str, path: str) -> Response:
@@ -291,11 +148,58 @@ class TexasTribune(NewSite):
         res = safe_get(API_URL, params=params, scrape_config=self.scrape_config)
         json_res = res.json()
 
-        metadata = [parse_metadata(article) for article in json_res["results"]]
+        metadata = [self.parse_metadata(article) for article in json_res["results"]]
         return metadata
 
+    def parse_metadata(
+        self, api_info: Dict[str, Any], external_id: Optional[str] = None, path: Optional[str] = None
+    ) -> Dict[str, Any]:
+        metadata = {}
+        parsers = [
+            ("title", self.get_title),
+            ("published_at", self.get_published_at),
+            ("path", self.get_path),
+            ("external_id", self.get_external_id),
+        ]
+        for prop, func in parsers:
+            try:
+                val = func(api_info)
+            except Exception as e:
+                if not external_id:
+                    external_id = "no_id_obtained"
+                if not path:
+                    path = "no_path_obtained"
+                raise ArticleScrapingError(
+                    ScrapeFailure.MALFORMED_RESPONSE, external_id, path, "Error parsing metadata for article"
+                ) from e
+            metadata[prop] = val
 
-NEW_TT_SITE = TexasTribune(
+        return metadata
+
+    @staticmethod
+    def get_title(res: dict) -> str:
+        title = res["headline"]
+        return title
+
+    @staticmethod
+    def get_published_at(res: dict) -> str:
+        # example published_at: '2021-11-12T12:45:35-06:00'
+        pub_date = res["pub_date"]
+        return pub_date
+
+    @staticmethod
+    def get_path(page: dict) -> str:
+        # there are times when older articles redirect to an alternate path, for ex:
+        # https://washingtoncitypaper.com/food/article/20830693/awardwinning-chef-michel-richard-dies-at-age-68
+        return urlparse(page["url"]).path
+
+    @staticmethod
+    def get_external_id(page: dict) -> str:
+        external_id = page["id"]
+        return external_id
+
+
+TT_SITE = TexasTribune(
     name=NAME,
     fields=FIELDS,
     training_params=TRAINING_PARAMS,

--- a/sites/texas_tribune.py
+++ b/sites/texas_tribune.py
@@ -227,7 +227,7 @@ class TexasTribune(NewSite):
 
         article_url = f"https://{DOMAIN}{path}"
         try:
-            page = safe_get(article_url, scrape_config=SCRAPE_CONFIG)
+            page = safe_get(article_url, scrape_config=self.scrape_config)
         except Exception as e:
             raise ArticleScrapingError(
                 ScrapeFailure.FETCH_ERROR,
@@ -265,7 +265,7 @@ class TexasTribune(NewSite):
         api_url = f"https://{DOMAIN}/api/v2/articles/{external_id}"
 
         try:
-            res = safe_get(api_url, scrape_config=SCRAPE_CONFIG)
+            res = safe_get(api_url, scrape_config=self.scrape_config)
         except Exception as e:
             raise ArticleScrapingError(
                 ScrapeFailure.FETCH_ERROR, path, external_id, f"Error fetching article url: {api_url}"
@@ -288,7 +288,7 @@ class TexasTribune(NewSite):
             "end_date": end_date.strftime(DATE_FORMAT),
             "limit": 100,
         }
-        res = safe_get(API_URL, params=params, scrape_config=SCRAPE_CONFIG)
+        res = safe_get(API_URL, params=params, scrape_config=self.scrape_config)
         json_res = res.json()
 
         metadata = [parse_metadata(article) for article in json_res["results"]]

--- a/sites/texas_tribune.py
+++ b/sites/texas_tribune.py
@@ -1,9 +1,10 @@
 import logging
 import re
 from datetime import date
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 from urllib.parse import urlparse
 
+import pandas as pd
 from bs4 import BeautifulSoup
 from requests.models import Response
 
@@ -16,7 +17,7 @@ from sites.helpers import (
     validate_response,
     validate_status_code,
 )
-from sites.site import Site
+from sites.site import NewSite, Site
 
 """
 TT API documentation
@@ -210,4 +211,31 @@ TT_SITE = Site(
     bulk_fetch,
     POPULARITY_WINDOW,
     MAX_ARTICLE_AGE,
+)
+
+
+class TexasTribune(NewSite):
+    def transform_raw_data(self, df: pd.DataFrame) -> pd.DataFrame:
+        pass
+
+    def extract_external_id(self, path: str) -> Optional[str]:
+        pass
+
+    def scrape_article_metadata(self, page: Union[Response, dict], external_id: str, path: str) -> dict:
+        pass
+
+    def fetch_article(self, external_id: str, path: str) -> Response:
+        pass
+
+    def bulk_fetch(self, start_date: date, end_date: date) -> List[Dict[str, Any]]:
+        pass
+
+
+NEW_TT_SITE = TexasTribune(
+    name=NAME,
+    fields=FIELDS,
+    training_params=TRAINING_PARAMS,
+    scrape_config=SCRAPE_CONFIG,
+    popularity_window=POPULARITY_WINDOW,
+    max_article_age=MAX_ARTICLE_AGE,
 )

--- a/sites/texas_tribune.py
+++ b/sites/texas_tribune.py
@@ -17,7 +17,7 @@ from sites.helpers import (
     validate_response,
     validate_status_code,
 )
-from sites.site import NewSite
+from sites.site import Site
 
 """
 TT API documentation
@@ -71,7 +71,7 @@ NON_ARTICLE_PREFIXES = [
 ]
 
 
-class TexasTribune(NewSite):
+class TexasTribune(Site):
     def transform_raw_data(self, df: pd.DataFrame) -> pd.DataFrame:
         return transform_data_google_tag_manager(df=df)
 

--- a/sites/washington_city_paper.py
+++ b/sites/washington_city_paper.py
@@ -1,6 +1,6 @@
 import re
 from datetime import date
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 from urllib.parse import urlparse
 
 import pandas as pd
@@ -15,7 +15,7 @@ from sites.helpers import (
     validate_response,
     validate_status_code,
 )
-from sites.site import Site
+from sites.site import NewSite
 
 POPULARITY_WINDOW = 7
 MAX_ARTICLE_AGE = 10
@@ -50,123 +50,117 @@ PATH_PATTERN = rf"\/((v|c)\/s\/{DOMAIN}\/)?article\/(\d+)\/\S+"
 PATH_PROG = re.compile(PATH_PATTERN)
 
 
-def bulk_fetch(start_date: date, end_date: date) -> List[Dict[str, Any]]:
-    raise NotImplementedError
+class WashingtonCityPaper(NewSite):
+    def transform_raw_data(self, df: pd.DataFrame) -> pd.DataFrame:
+        """
+        requires a dataframe with the following fields:
+        - contexts_dev_amp_snowplow_amp_id_1
+        - collector_tstamp
+        - page_urlpath
+        returns a dataframe with the following fields:
+        - client_id
+        - session_date
+        - activity_time
+        - landing_page_path
+        - event_category (conversions, newsletter sign-ups TK)
+        - event_action (conversions, newsletter sign-ups TK)
+        """
+        df = df.dropna(subset=["contexts_dev_amp_snowplow_amp_id_1"])
+        transformed_df = pd.DataFrame()
+        transformed_df["client_id"] = df.contexts_dev_amp_snowplow_amp_id_1.apply(lambda x: x[0]["ampClientId"])
+        transformed_df["activity_time"] = pd.to_datetime(df.collector_tstamp).dt.round("1s")
+        transformed_df["session_date"] = pd.to_datetime(transformed_df.activity_time.dt.date)
+        transformed_df["landing_page_path"] = df.page_urlpath
+        transformed_df["event_name"] = df.event_name
+        transformed_df.replace({"event_name": "amp_page_ping"}, Event.PAGE_PING.value, inplace=True)
+        transformed_df["event_name"] = transformed_df["event_name"].astype("category")
 
+        return transformed_df
 
-def transform_raw_data(df: pd.DataFrame) -> pd.DataFrame:
-    """
-    requires a dataframe with the following fields:
-    - contexts_dev_amp_snowplow_amp_id_1
-    - collector_tstamp
-    - page_urlpath
-    returns a dataframe with the following fields:
-    - client_id
-    - session_date
-    - activity_time
-    - landing_page_path
-    - event_category (conversions, newsletter sign-ups TK)
-    - event_action (conversions, newsletter sign-ups TK)
-    """
-    df = df.dropna(subset=["contexts_dev_amp_snowplow_amp_id_1"])
-    transformed_df = pd.DataFrame()
-    transformed_df["client_id"] = df.contexts_dev_amp_snowplow_amp_id_1.apply(lambda x: x[0]["ampClientId"])
-    transformed_df["activity_time"] = pd.to_datetime(df.collector_tstamp).dt.round("1s")
-    transformed_df["session_date"] = pd.to_datetime(transformed_df.activity_time.dt.date)
-    transformed_df["landing_page_path"] = df.page_urlpath
-    transformed_df["event_name"] = df.event_name
-    transformed_df.replace({"event_name": "amp_page_ping"}, Event.PAGE_PING.value, inplace=True)
-    transformed_df["event_name"] = transformed_df["event_name"].astype("category")
+    def extract_external_id(self, path: str) -> Optional[str]:
+        result = PATH_PROG.match(path)
+        if result:
+            return result.groups()[2]
+        else:
+            raise ArticleScrapingError(
+                ScrapeFailure.NO_EXTERNAL_ID, path, external_id=None, msg="External ID not found in path"
+            )
 
-    return transformed_df
+    def scrape_article_metadata(self, page: Union[Response, dict], external_id: str, path: str) -> dict:
+        soup = BeautifulSoup(page.text, features="html.parser")
+        metadata = {}
+        scraper_funcs = [
+            ("title", self.scrape_title),
+            ("published_at", self.scrape_published_at),
+            ("path", self.scrape_path),
+        ]
 
+        for prop, func in scraper_funcs:
+            try:
+                val = func(page, soup)
+            except Exception as e:
+                raise ArticleScrapingError(
+                    ScrapeFailure.MALFORMED_RESPONSE, path, external_id, f"Error scraping {prop} for article path"
+                ) from e
+            metadata[prop] = val
 
-def extract_external_id(path: str) -> str:
-    result = PATH_PROG.match(path)
-    if result:
-        return result.groups()[2]
-    else:
-        raise ArticleScrapingError(
-            ScrapeFailure.NO_EXTERNAL_ID, path, external_id=None, msg="External ID not found in path"
-        )
+        return metadata
 
+    def fetch_article(self, external_id: str, path: str) -> Response:
+        url = f"https://{DOMAIN}{path}"
 
-def scrape_title(page: Response, soup: BeautifulSoup) -> str:
-    headers = soup.select("header h1")
-    return headers[0].text.strip()
-
-
-def scrape_published_at(page: Response, soup: BeautifulSoup) -> str:
-    # example published_at: '2021-04-13T19:00:45+00:00'
-    PROPERTY_TAG = "article:published_time"
-    tag = soup.find("meta", property=PROPERTY_TAG)
-    return tag.get("content") if tag is not None else None
-
-
-def scrape_path(page: Response, soup: BeautifulSoup) -> str:
-    # there are times when older articles redirect to an alternate path, for ex:
-    # https://washingtoncitypaper.com/food/article/20830693/awardwinning-chef-michel-richard-dies-at-age-68
-    return urlparse(page.url).path
-
-
-def scrape_article_metadata(page: Response, external_id: str, path: str) -> dict:
-    soup = BeautifulSoup(page.text, features="html.parser")
-    metadata = {}
-    scraper_funcs = [
-        ("title", scrape_title),
-        ("published_at", scrape_published_at),
-        ("path", scrape_path),
-    ]
-
-    for prop, func in scraper_funcs:
         try:
-            val = func(page, soup)
+            page = safe_get(url)
         except Exception as e:
             raise ArticleScrapingError(
-                ScrapeFailure.MALFORMED_RESPONSE, path, external_id, f"Error scraping {prop} for article path"
+                ScrapeFailure.FETCH_ERROR, path, str(external_id), f"Request failed for {url}"
             ) from e
-        metadata[prop] = val
 
-    return metadata
+        error_msg = validate_response(page, [validate_status_code, self.validate_not_excluded])
+        if error_msg is not None:
+            raise ArticleScrapingError(ScrapeFailure.FAILED_SITE_VALIDATION, path, str(external_id), error_msg)
+
+        return page
+
+    def bulk_fetch(self, start_date: date, end_date: date) -> List[Dict[str, Any]]:
+        raise NotImplementedError
+
+    @staticmethod
+    def validate_not_excluded(page: Response) -> Optional[str]:
+        soup = BeautifulSoup(page.text, features="html.parser")
+        primary = soup.find(id="primary")
+
+        if primary:
+            classes = {value for element in primary.find_all(class_=True) for value in element["class"]}
+            if "tag-exclude" in classes:
+                return "Article has exclude tag"
+
+        return None
+
+    @staticmethod
+    def scrape_path(page: Response, soup: BeautifulSoup) -> str:
+        # there are times when older articles redirect to an alternate path, for ex:
+        # https://washingtoncitypaper.com/food/article/20830693/awardwinning-chef-michel-richard-dies-at-age-68
+        return urlparse(page.url).path
+
+    @staticmethod
+    def scrape_title(page: Response, soup: BeautifulSoup) -> str:
+        headers = soup.select("header h1")
+        return headers[0].text.strip()
+
+    @staticmethod
+    def scrape_published_at(page: Response, soup: BeautifulSoup) -> str:
+        # example published_at: '2021-04-13T19:00:45+00:00'
+        PROPERTY_TAG = "article:published_time"
+        tag = soup.find("meta", property=PROPERTY_TAG)
+        return tag.get("content") if tag is not None else None
 
 
-def validate_not_excluded(page: Response) -> Optional[str]:
-    soup = BeautifulSoup(page.text, features="html.parser")
-    primary = soup.find(id="primary")
-
-    if primary:
-        classes = {value for element in primary.find_all(class_=True) for value in element["class"]}
-        if "tag-exclude" in classes:
-            return "Article has exclude tag"
-
-    return None
-
-
-def fetch_article(external_id: str, path: str) -> Response:
-    url = f"https://{DOMAIN}{path}"
-
-    try:
-        page = safe_get(url)
-    except Exception as e:
-        raise ArticleScrapingError(ScrapeFailure.FETCH_ERROR, path, str(external_id), f"Request failed for {url}") from e
-
-    error_msg = validate_response(page, [validate_status_code, validate_not_excluded])
-    if error_msg is not None:
-        raise ArticleScrapingError(ScrapeFailure.FAILED_SITE_VALIDATION, path, str(external_id), error_msg)
-
-    return page
-
-
-WCP_SITE = Site(
-    NAME,
-    FIELDS,
-    TRAINING_PARAMS,
-    SCRAPE_CONFIG,
-    transform_raw_data,
-    extract_external_id,
-    scrape_article_metadata,
-    fetch_article,
-    bulk_fetch,
-    POPULARITY_WINDOW,
-    MAX_ARTICLE_AGE,
+WCP_SITE = WashingtonCityPaper(
+    name=NAME,
+    fields=FIELDS,
+    training_params=TRAINING_PARAMS,
+    scrape_config=SCRAPE_CONFIG,
+    popularity_window=POPULARITY_WINDOW,
+    max_article_age=MAX_ARTICLE_AGE,
 )

--- a/sites/washington_city_paper.py
+++ b/sites/washington_city_paper.py
@@ -15,7 +15,7 @@ from sites.helpers import (
     validate_response,
     validate_status_code,
 )
-from sites.site import NewSite
+from sites.site import Site
 
 POPULARITY_WINDOW = 7
 MAX_ARTICLE_AGE = 10
@@ -50,7 +50,7 @@ PATH_PATTERN = rf"\/((v|c)\/s\/{DOMAIN}\/)?article\/(\d+)\/\S+"
 PATH_PROG = re.compile(PATH_PATTERN)
 
 
-class WashingtonCityPaper(NewSite):
+class WashingtonCityPaper(Site):
     def transform_raw_data(self, df: pd.DataFrame) -> pd.DataFrame:
         """
         requires a dataframe with the following fields:

--- a/tests/sites/test_philadelphia_inquirer.py
+++ b/tests/sites/test_philadelphia_inquirer.py
@@ -1,6 +1,6 @@
 from copy import deepcopy
 
-import sites.philadelphia_inquirer as site
+from sites.philadelphia_inquirer import PI_SITE
 from tests.base import BaseTest
 
 
@@ -19,10 +19,10 @@ class TestPhiladelphiaInquirer(BaseTest):
         super().setUp()
 
     def test_get_headline(self) -> None:
-        title = site.get_headline(self.res)
+        title = PI_SITE.get_headline(self.res)
         assert title == self.res["headlines"]["meta_title"]
 
     def test_get_headline__empty_meta_title(self) -> None:
         self.res["headlines"]["meta_title"] = ""
-        title = site.get_headline(self.res)
+        title = PI_SITE.get_headline(self.res)
         assert title == self.res["headlines"]["basic"]

--- a/tests/test_fetch_data.py
+++ b/tests/test_fetch_data.py
@@ -2,7 +2,7 @@ import pandas as pd
 import pytest
 
 from lib.config import ROOT_DIR
-from sites.washington_city_paper import transform_raw_data
+from sites.washington_city_paper import WCP_SITE
 
 
 @pytest.fixture(scope="module")
@@ -14,7 +14,7 @@ def snowplow_df():
 
 
 def test_transform_raw_data(snowplow_df):
-    df = transform_raw_data(snowplow_df)
+    df = WCP_SITE.transform_raw_data(snowplow_df)
     assert (df.session_date == pd.to_datetime("2021-02-11")).all()
     assert set(df.columns) == {
         "activity_time",


### PR DESCRIPTION
This PR updates the Site object. It was previously a named tuple. `Site` is now an abstract base class, a data class, and a singleton. This means that when a class uses it as its metaclass, the following happens:
- There can only be one instantiation of the class (singleton pattern)
- It expects certain functions to be implemented (abstract base class)
- It expects certain properties to be passed in (data class)

The reason we are doing this is to enforce stricter structure and typing on this central configuration object. It is a common pattern across each partner site, and by adding all this strictness we reduce the probability of bugs. (For example, the named tuple approach would allow someone to define the "extract_external_id" field as a literal integer. That would break the program. The new approach provides many more guardrails to ensure that function accepts certain inputs of certain types and outputs certain outputs of certain types.)