### PR TITLE
SS: Change Site object to accommodate different rec approaches

### DIFF
--- a/job/job.py
+++ b/job/job.py
@@ -59,7 +59,7 @@ def run():
 
         recommendations = train_model.get_recommendations(
             interactions_data,
-            site.training_params,
+            site.config.collaborative_filtering.training_params,
             EXPERIMENT_DT,
         )
         logging.info(f"Successfully trained model on {len(interactions_data)} inputs.")

--- a/job/steps/collaborative_filtering/fetch_data.py
+++ b/job/steps/collaborative_filtering/fetch_data.py
@@ -67,13 +67,14 @@ def transform_chunk(site: Site, dt: datetime.datetime) -> List[pd.DataFrame]:
 
     path = os.path.join(PATH, chunk_name(dt))
     filenames = gen_files(path)
+    fields = site.config.collaborative_filtering.snowplow_fields
 
     dfs = []
 
     for filename in filenames:
         file_path = os.path.join(path, filename)
 
-        df = fast_read(file_path, site.fields)
+        df = fast_read(file_path, fields)
         df = site.transform_raw_data(df)
         df = aggregate_page_pings(df)
 

--- a/job/steps/collaborative_filtering/scrape_metadata.py
+++ b/job/steps/collaborative_filtering/scrape_metadata.py
@@ -124,7 +124,8 @@ def extract_external_ids(site: Site, landing_page_paths: List[str]) -> List[Unio
     futures_list = []
     results: List[Union[str, ArticleScrapingError]] = []
 
-    with ThreadPoolExecutor(max_workers=site.scrape_config["concurrent_requests"]) as executor:
+    max_workers = site.config.collaborative_filtering.scrape_config["concurrent_requests"]
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
         for path in landing_page_paths:
             future = executor.submit(extract_external_id, site, path=path)
             futures_list.append((path, future))
@@ -173,7 +174,9 @@ def scrape_articles(site: Site, articles: List[Article]) -> Tuple[List[Article],
     futures_list = []
     results: List[Article] = []
     errors: List[ArticleScrapingError] = []
-    with ThreadPoolExecutor(max_workers=site.scrape_config["concurrent_requests"]) as executor:
+
+    max_workers = site.config.collaborative_filtering.scrape_config["concurrent_requests"]
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
         for article in articles:
             future = executor.submit(scrape_article, site, article=article)
             futures_list.append(future)

--- a/job/steps/collaborative_filtering/warehouse.py
+++ b/job/steps/collaborative_filtering/warehouse.py
@@ -242,7 +242,7 @@ def get_dwell_times(site: Site, days=28) -> pd.DataFrame:
     and num_articles_per_user > 2
     and duration between 30 and 600
     and duration_per_user > 60
-    and {article_table}.published_at > current_date - {site.max_article_age * 365}
+    and {article_table}.published_at > current_date - {site.config.collaborative_filtering.max_article_age * 365}
     """
     conn = get_connection()
     with conn.cursor() as cursor:
@@ -265,7 +265,7 @@ def get_default_recs(site: Site, limit=50):
     """
     Pull the articles that were the most popular in the last {days} days
     """
-    days = site.popularity_window
+    days = site.config.popularity.popularity_window
     logging.info(f"Fetching default recs for {days}-day window")
     table = get_table(Table.DWELL_TIMES)
     query = f"""

--- a/sites/config.py
+++ b/sites/config.py
@@ -3,8 +3,7 @@ from typing import List, Optional, Set, TypedDict
 
 # Custom types
 # TypedDict (as opposed to dataclass) doesn't require changing existing CF code to work with it
-# (especially when CF train_model.py requires train_params to be a dict in order to run dict.update),
-# but open to stricter suggestions.
+# (especially when CF train_model.py requires train_params to be a dict in order to call dict.update)
 
 
 class ScrapeConfig(TypedDict):

--- a/sites/config.py
+++ b/sites/config.py
@@ -70,6 +70,11 @@ class ConfigPop:
 class SiteConfig:
     """
     Site config object for different model configs
+
+    In order to add a new model (not a new approach/strategy, which may or may not require adding a new model)
+    to the site:
+    1. Create a Config<ModelName> dataclass with appropriate config variables and variable types
+    2. Add created config dataclass to this class as a property
     """
 
     # Popularity model is fallback and therefore its config is not optional

--- a/sites/config.py
+++ b/sites/config.py
@@ -1,0 +1,75 @@
+from dataclasses import dataclass
+from typing import List, Optional, Set, TypedDict
+
+# Custom types
+# TypedDict (as opposed to dataclass) doesn't require changing existing CF code in the job directory
+# to work with it, but open to stricter suggestions.
+
+
+class ScrapeConfig(TypedDict):
+    """
+    Scraping config.
+    """
+
+    concurrent_requests: int
+    requests_per_second: int
+
+
+class TrainParamsCF(TypedDict):
+    """
+    Training params for collaborative filtering.
+    """
+
+    hl: int
+    embedding_dim: int
+    epochs: int
+    tune: bool
+    tune_params: List[str]
+    tune_ranges: List[List[int]]
+    model: str
+    loss: str
+
+
+# Config dataclasses
+
+
+@dataclass
+class ConfigCF:
+    """
+    Collborative-filtering site configs.
+    """
+
+    snowplow_fields: Set[str]
+    scrape_config: ScrapeConfig
+    training_params: TrainParamsCF
+    max_article_age: int
+
+
+@dataclass
+class ConfigSS:
+    """
+    TODO: Semantic-similarity site configs.
+    """
+
+    pass
+
+
+@dataclass
+class ConfigPop:
+    """
+    Default popularity model configs.
+    """
+
+    popularity_window: int
+
+
+@dataclass
+class SiteConfig:
+    """
+    Site config object for different model configs
+    """
+
+    # Popularity model is fallback and therefore its config is not optional
+    popularity: ConfigPop
+    collaborative_filtering: Optional[ConfigCF] = None
+    semantic_similarity: Optional[ConfigSS] = None

--- a/sites/config.py
+++ b/sites/config.py
@@ -2,8 +2,9 @@ from dataclasses import dataclass
 from typing import List, Optional, Set, TypedDict
 
 # Custom types
-# TypedDict (as opposed to dataclass) doesn't require changing existing CF code in the job directory
-# to work with it, but open to stricter suggestions.
+# TypedDict (as opposed to dataclass) doesn't require changing existing CF code to work with it
+# (especially when CF train_model.py requires train_params to be a dict in order to run dict.update),
+# but open to stricter suggestions.
 
 
 class ScrapeConfig(TypedDict):

--- a/sites/config.py
+++ b/sites/config.py
@@ -42,6 +42,7 @@ class ConfigCF:
     snowplow_fields: Set[str]
     scrape_config: ScrapeConfig
     training_params: TrainParamsCF
+    # this is a number of years; will grab dwell time data for any article within the past X years
     max_article_age: int
 
 
@@ -57,9 +58,10 @@ class ConfigSS:
 @dataclass
 class ConfigPop:
     """
-    Default popularity model configs.
+    Default popularity-model site configs.
     """
 
+    # this is a number of days; will only recommend articles within the past X days
     popularity_window: int
 
 

--- a/sites/philadelphia_inquirer.py
+++ b/sites/philadelphia_inquirer.py
@@ -275,6 +275,7 @@ class PhiladelphiaInquirer(Site):
 PI_SITE = PhiladelphiaInquirer(
     name=NAME,
     strategy=Strategy.COLLABORATIVE_FILTERING,
+    strategy_fallback=Strategy.POPULARITY,
     config=SiteConfig(
         collaborative_filtering=ConfigCF(
             snowplow_fields=SNOWPLOW_FIELDS,

--- a/sites/philadelphia_inquirer.py
+++ b/sites/philadelphia_inquirer.py
@@ -283,10 +283,5 @@ PI_SITE = PhiladelphiaInquirer(
             max_article_age=MAX_ARTICLE_AGE,
         ),
         popularity=ConfigPop(popularity_window=POPULARITY_WINDOW),
-    )
-    # fields=FIELDS,
-    # training_params=TRAINING_PARAMS,
-    # scrape_config=SCRAPE_CONFIG,
-    # popularity_window=POPULARITY_WINDOW,
-    # max_article_age=MAX_ARTICLE_AGE,
+    ),
 )

--- a/sites/site.py
+++ b/sites/site.py
@@ -1,24 +1,21 @@
 from abc import abstractmethod
 from dataclasses import dataclass
 from datetime import date
-from typing import Any, Dict, List, Optional, Set, Union
+from typing import Any, Dict, List, Optional, Union
 
 import pandas as pd
 from requests.models import Response
 
+from sites.config import SiteConfig
 from sites.singleton import SingletonABCMeta
+from sites.strategy import Strategy
 
 
 @dataclass
 class Site(metaclass=SingletonABCMeta):
     name: str
-    fields: Set[str]  # needs better name
-    training_params: dict  # should define with more specifics unless it needs to be flexible
-    scrape_config: dict  # should define with more specifics unless it needs to be flexible
-    # this is a number of days; will only recommend articles within the past X days
-    popularity_window: int
-    # this is a number of years; will grab dwell time data for any article within the past X years
-    max_article_age: int
+    strategy: Strategy
+    config: SiteConfig
 
     def get_bucket_name(self):
         return f"lnl-snowplow-{self.name}"

--- a/sites/site.py
+++ b/sites/site.py
@@ -14,7 +14,10 @@ from sites.strategy import Strategy
 @dataclass
 class Site(metaclass=SingletonABCMeta):
     name: str
+    # Main recs-generating approach, e.g., CF or SS
     strategy: Strategy
+    # Backup/default recs-generating approach, e.g., popularity
+    strategy_fallback: Strategy
     config: SiteConfig
 
     def get_bucket_name(self):

--- a/sites/strategy.py
+++ b/sites/strategy.py
@@ -1,0 +1,16 @@
+from enum import Enum
+
+
+class Strategy(Enum):
+    """
+    Simple Enum containing different recs-generating approaches, to be passed into Site object
+    as a class property. Job will look at this to decide which scripts to run.
+
+    TODO: Unify with db/model.py?
+    """
+
+    COLLABORATIVE_FILTERING = "collaborative_filtering"
+    SEMANTIC_SIMILARITY = "semantic_similarity"
+    POPULARITY = "popularity"  # Default popularity approach as fallback. Will always be run.
+    # Add new approaches here (which may use one or more models/model configs, e.g., SS, CF)
+    # e.g., HYBRID_SS_CF = "hybrid_ss_cf"

--- a/sites/strategy.py
+++ b/sites/strategy.py
@@ -9,8 +9,11 @@ class Strategy(Enum):
     TODO: Unify with db/model.py?
     """
 
+    # Article-based collaborative filtering (as opposed to user-based, which is mentioned in db/model.py
+    # but never used and generally have gone out of favor)
     COLLABORATIVE_FILTERING = "collaborative_filtering"
     SEMANTIC_SIMILARITY = "semantic_similarity"
     POPULARITY = "popularity"  # Default popularity approach as fallback. Will always be run.
-    # Add new approaches here (which may use one or more models/model configs, e.g., SS, CF)
+    # Add new approaches here (which may use one or more models/model configs; for example,
+    # an SS-CF hybrid requires both SS config and CF config)
     # e.g., HYBRID_SS_CF = "hybrid_ss_cf"

--- a/sites/strategy.py
+++ b/sites/strategy.py
@@ -12,8 +12,13 @@ class Strategy(Enum):
     # Article-based collaborative filtering (as opposed to user-based, which is mentioned in db/model.py
     # but never used and generally have gone out of favor)
     COLLABORATIVE_FILTERING = "collaborative_filtering"
+
+    # Semantic similarity
     SEMANTIC_SIMILARITY = "semantic_similarity"
-    POPULARITY = "popularity"  # Default popularity approach as fallback. Will always be run.
+
+    # Default popularity approach as API fallback. Will always be run.
+    POPULARITY = "popularity"
+
     # Add new approaches here (which may use one or more models/model configs; for example,
     # an SS-CF hybrid requires both SS config and CF config)
     # e.g., HYBRID_SS_CF = "hybrid_ss_cf"

--- a/sites/texas_tribune.py
+++ b/sites/texas_tribune.py
@@ -8,6 +8,7 @@ import pandas as pd
 from bs4 import BeautifulSoup
 from requests.models import Response
 
+from sites.config import ConfigCF, ConfigPop, ScrapeConfig, SiteConfig, TrainParamsCF
 from sites.helpers import (
     GOOGLE_TAG_MANAGER_RAW_FIELDS,
     ArticleBatchScrapingError,
@@ -19,6 +20,7 @@ from sites.helpers import (
     validate_status_code,
 )
 from sites.site import Site
+from sites.strategy import Strategy
 
 """
 TT API documentation
@@ -31,8 +33,8 @@ DOMAIN = "www.texastribune.org"
 NAME = "texas-tribune"
 BULK_FETCH_LIMIT = 100  # Texas Tribune places a hard 100-article max limit on pagination
 BULK_FETCH_LOG_INTERVAL = 500
-FIELDS = GOOGLE_TAG_MANAGER_RAW_FIELDS
-TRAINING_PARAMS = {
+SNOWPLOW_FIELDS = GOOGLE_TAG_MANAGER_RAW_FIELDS
+TRAINING_PARAMS: TrainParamsCF = {
     "hl": 90,
     "embedding_dim": 100,
     "epochs": 3,
@@ -43,7 +45,7 @@ TRAINING_PARAMS = {
     "tune_ranges": [[5, 11, 2], [160, 360, 100]],
 }
 
-SCRAPE_CONFIG = {
+SCRAPE_CONFIG: ScrapeConfig = {
     "concurrent_requests": 1,
     "requests_per_second": 2,
 }
@@ -84,7 +86,7 @@ class TexasTribune(Site):
 
         article_url = f"https://{DOMAIN}{path}"
         try:
-            page = safe_get(article_url, scrape_config=self.scrape_config)
+            page = safe_get(article_url, scrape_config=self.config.collaborative_filtering.scrape_config)
         except Exception as e:
             raise ArticleScrapingError(
                 ScrapeFailure.FETCH_ERROR,
@@ -122,7 +124,7 @@ class TexasTribune(Site):
         api_url = f"https://{DOMAIN}/api/v2/articles/{external_id}"
 
         try:
-            res = safe_get(api_url, scrape_config=self.scrape_config)
+            res = safe_get(api_url, scrape_config=self.config.collaborative_filtering.scrape_config)
         except Exception as e:
             raise ArticleScrapingError(
                 ScrapeFailure.FETCH_ERROR, path, external_id, f"Error fetching article url: {api_url}"
@@ -145,7 +147,7 @@ class TexasTribune(Site):
             "end_date": end_date.strftime(DATE_FORMAT),
             "limit": BULK_FETCH_LIMIT,
         }
-        res = safe_get(API_URL, params=params, scrape_config=self.scrape_config)
+        res = safe_get(API_URL, params=params, scrape_config=self.config.collaborative_filtering.scrape_config)
         json_res = res.json()
 
         metadata = [self.parse_metadata(article) for article in json_res["results"]]
@@ -264,9 +266,14 @@ class TexasTribune(Site):
 
 TT_SITE = TexasTribune(
     name=NAME,
-    fields=FIELDS,
-    training_params=TRAINING_PARAMS,
-    scrape_config=SCRAPE_CONFIG,
-    popularity_window=POPULARITY_WINDOW,
-    max_article_age=MAX_ARTICLE_AGE,
+    strategy=Strategy.COLLABORATIVE_FILTERING,
+    config=SiteConfig(
+        collaborative_filtering=ConfigCF(
+            snowplow_fields=SNOWPLOW_FIELDS,
+            scrape_config=SCRAPE_CONFIG,
+            training_params=TRAINING_PARAMS,
+            max_article_age=MAX_ARTICLE_AGE,
+        ),
+        popularity=ConfigPop(popularity_window=POPULARITY_WINDOW),
+    ),
 )

--- a/sites/texas_tribune.py
+++ b/sites/texas_tribune.py
@@ -267,6 +267,7 @@ class TexasTribune(Site):
 TT_SITE = TexasTribune(
     name=NAME,
     strategy=Strategy.COLLABORATIVE_FILTERING,
+    strategy_fallback=Strategy.POPULARITY,
     config=SiteConfig(
         collaborative_filtering=ConfigCF(
             snowplow_fields=SNOWPLOW_FIELDS,

--- a/sites/washington_city_paper.py
+++ b/sites/washington_city_paper.py
@@ -170,6 +170,7 @@ class WashingtonCityPaper(Site):
 WCP_SITE = WashingtonCityPaper(
     name=NAME,
     strategy=Strategy.COLLABORATIVE_FILTERING,
+    strategy_fallback=Strategy.POPULARITY,
     config=SiteConfig(
         collaborative_filtering=ConfigCF(
             snowplow_fields=SNOWPLOW_FIELDS,

--- a/sites/washington_city_paper.py
+++ b/sites/washington_city_paper.py
@@ -8,6 +8,7 @@ from bs4 import BeautifulSoup
 from requests.models import Response
 
 from lib.events import Event
+from sites.config import ConfigCF, ConfigPop, ScrapeConfig, SiteConfig, TrainParamsCF
 from sites.helpers import (
     ArticleScrapingError,
     ScrapeFailure,
@@ -16,18 +17,19 @@ from sites.helpers import (
     validate_status_code,
 )
 from sites.site import Site
+from sites.strategy import Strategy
 
 POPULARITY_WINDOW = 7
 MAX_ARTICLE_AGE = 10
 DOMAIN = "washingtoncitypaper.com"
 NAME = "washington-city-paper"
-FIELDS = {
+SNOWPLOW_FIELDS = {
     "collector_tstamp",
     "page_urlpath",
     "contexts_dev_amp_snowplow_amp_id_1",
     "event_name",
 }
-TRAINING_PARAMS = {
+TRAINING_PARAMS: TrainParamsCF = {
     "hl": 30,
     "embedding_dim": 144,
     "epochs": 3,
@@ -38,7 +40,7 @@ TRAINING_PARAMS = {
     "tune_ranges": [[1, 5, 1], [40, 300, 20]],
 }
 
-SCRAPE_CONFIG = {
+SCRAPE_CONFIG: ScrapeConfig = {
     "concurrent_requests": 1,
     "requests_per_second": 2,
 }
@@ -167,9 +169,14 @@ class WashingtonCityPaper(Site):
 
 WCP_SITE = WashingtonCityPaper(
     name=NAME,
-    fields=FIELDS,
-    training_params=TRAINING_PARAMS,
-    scrape_config=SCRAPE_CONFIG,
-    popularity_window=POPULARITY_WINDOW,
-    max_article_age=MAX_ARTICLE_AGE,
+    strategy=Strategy.COLLABORATIVE_FILTERING,
+    config=SiteConfig(
+        collaborative_filtering=ConfigCF(
+            snowplow_fields=SNOWPLOW_FIELDS,
+            scrape_config=SCRAPE_CONFIG,
+            training_params=TRAINING_PARAMS,
+            max_article_age=MAX_ARTICLE_AGE,
+        ),
+        popularity=ConfigPop(popularity_window=POPULARITY_WINDOW),
+    ),
 )


### PR DESCRIPTION
## Description
This PR attempts to minimally change the current `Site` object so that it works with different recommendation approaches/strategies (CF, SS, CF-SS hybrid, or something else). There are two main changes:

- `Site` properties that currently are config variables for the CF model (`fields`, `training_params`, `scrape_config`, `max_article_age`) and for the default popularity model (`popularity_window`) are moved to the models' respective config dataclasses. These dataclasses are defined in `sites/config.py`. A new property `Site.config` is added, which itself is a dataclass housing all the different config dataclasses a site requires.
- Toward the ability to toggle between different recommendation strategies, two new `Site` properties are added, `Site.strategy` and `Site.strategy_fallback`. Each takes on an enum value representing a recommendation strategy (CF, SS, popularity, CF-SS hybrid, etc.) as shown in `sites/strategy.py`. _A recommendation strategy may use one (e.g., popularity, SS, CF) or more (e.g., CF-SS hybrid) recommendation models and thus reqiure one or more model config dataclasses._

Changes to the `job` directory are only scoped within the first bullet point, not the second (i.e., to make the CF job works with the updated site model configs, not with the newly created strategy enums).

## Testing
All unit tests passed. 

🌱 Mypy's throwing a bunch of errors from previous PRs merged into `semantic-similarity`, which we can certainly deal with later.

## Notes
🌱 If this PR is approved and merged, the next PR should reorganize the `sites` directory.
🌱 It would be great to find a way to unify the recommendation strategy enum with the model/strategy database schema in `db/mappings/model.py`.