### PR TITLE
Remove deletion upon error in article database update for TT and PI

### DIFF
--- a/job/steps/scrape_metadata.py
+++ b/job/steps/scrape_metadata.py
@@ -17,6 +17,10 @@ from job.steps import warehouse
 from lib.metrics import Unit, write_metric
 from sites.helpers import ArticleScrapingError, ScrapeFailure
 from sites.site import Site
+from sites.sites import Sites
+from sites.washington_city_paper import (
+    ERROR_MSG_TAG_EXCLUDE as WCP_ERROR_MSG_TAG_EXCLUDE,
+)
 
 EXCLUDE_FAILURE_TYPES = {
     ScrapeFailure.NO_EXTERNAL_ID,
@@ -256,8 +260,9 @@ def scrape_and_update_articles(site: Site, external_ids: List[str]) -> Tuple[Lis
 
     results, errors = scrape_articles(site, articles)
 
-    # Delete any articles from the DB that had a scraping error
-    delete_articles([e.external_id for e in errors])
+    # WCP: Delete any sponsored (excluded) articles from the DB that had a tag-exclude scraping error
+    if site.name == Sites.WCP.name:
+        delete_articles([e.external_id for e in errors if e.msg == WCP_ERROR_MSG_TAG_EXCLUDE])
 
     # Filter for articles that have a published_at date
     to_update = []

--- a/sites/washington_city_paper.py
+++ b/sites/washington_city_paper.py
@@ -49,6 +49,9 @@ SCRAPE_CONFIG = {
 PATH_PATTERN = rf"\/((v|c)\/s\/{DOMAIN}\/)?article\/(\d+)\/\S+"
 PATH_PROG = re.compile(PATH_PATTERN)
 
+# TODO: Once merged Site object PR, make this a WCP class attribute
+ERROR_MSG_TAG_EXCLUDE = "Article has exclude tag"
+
 
 def bulk_fetch(start_date: date, end_date: date) -> List[Dict[str, Any]]:
     raise NotImplementedError
@@ -137,7 +140,7 @@ def validate_not_excluded(page: Response) -> Optional[str]:
     if primary:
         classes = {value for element in primary.find_all(class_=True) for value in element["class"]}
         if "tag-exclude" in classes:
-            return "Article has exclude tag"
+            return ERROR_MSG_TAG_EXCLUDE
 
     return None
 

--- a/tests/test_scrape_metadata.py
+++ b/tests/test_scrape_metadata.py
@@ -9,12 +9,19 @@ from job.steps.scrape_metadata import scrape_upload_metadata
 from sites.helpers import ArticleScrapingError, ScrapeFailure
 from sites.site import Site
 from sites.sites import Sites
+from sites.washington_city_paper import ERROR_MSG_TAG_EXCLUDE
 from tests.base import BaseTest
 from tests.factories.article import ArticleFactory
 
 
 def scrape_error(site, article):
     raise ArticleScrapingError(ScrapeFailure.UNKNOWN, article.path, article.external_id)
+
+
+def invalid_scrape_error(site, article):
+    raise ArticleScrapingError(
+        ScrapeFailure.FAILED_SITE_VALIDATION, article.path, article.external_id, ERROR_MSG_TAG_EXCLUDE
+    )
 
 
 def safe_scrape_error(site, article):
@@ -120,7 +127,7 @@ class TestScrapeMetadata(BaseTest):
     @patch(
         "job.steps.scrape_metadata.scrape_article",
         return_value=None,
-        side_effect=scrape_error,
+        side_effect=invalid_scrape_error,
     )
     def test_scrape_metadata__existing_invalid_recs(self, _, __) -> None:
         for external_id in self.external_ids:


### PR DESCRIPTION
## Description

Recently, a slew of [Postgres errors](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/ArticleRecTrainingJobLogGroup/log-events/TexasTribuneArticleRecTrainingJob$252FTexasTribuneArticleRecTrainingJobTaskContainer$252Fb5343b2c8f0140d5916c71b2c81e46c4) happened because the job prematurely deleted a Texas Tribune article from the `article` table upon encountering a 404 error while trying to rescrape and update it.

This PR restricts this deletion logic to sponsored (excluded) articles from the Washington City Paper, as separating original and sponsored WCP content was the only motivation toward deletion (see #55).

## Testing

A single test inside `tests/test_scraped_metadata.py` was modified to accommodate this change. All tests passed.