### PR TITLE
refactor CollaborativeFiltering and SemanticSimilarity as subclasses of Strategy

### DIFF
--- a/db/helpers.py
+++ b/db/helpers.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import logging
-from typing import Iterable, List, Type
+from typing import TYPE_CHECKING, Iterable, List, Type
 
 from peewee import Expression
 
@@ -7,7 +9,9 @@ from db.mappings.article import Article
 from db.mappings.base import BaseMapping, db_proxy, tzaware_now
 from db.mappings.model import Model, ModelType, Status
 from db.mappings.recommendation import Rec
-from sites.templates.site import Site
+
+if TYPE_CHECKING:
+    from sites.templates.site import Site
 
 
 def refresh_db(func):

--- a/db/mappings/model.py
+++ b/db/mappings/model.py
@@ -9,6 +9,7 @@ class ModelType(enum.Enum):
     ARTICLE = "article"
     USER = "user"
     POPULARITY = "popularity"
+    SEMANTIC_SIMILARITY = "semantic-similarity"
 
 
 class Status(enum.Enum):

--- a/job/strategies/collaborative_filtering.py
+++ b/job/strategies/collaborative_filtering.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from typing import List, Set, TypedDict
 
 import pandas as pd
@@ -39,33 +38,28 @@ class CollaborativeFiltering(Strategy):
     Collaborative-filtering site configs and methods.
     """
 
-    interactions_data: pd.DataFrame
-    experiment_time: datetime
-    snowplow_fields: Set[str]
-    scrape_config: ScrapeConfig
-    training_params: TrainParamsCF
-    model_type: ModelType = ModelType.ARTICLE
-    # this is a number of years; will grab dwell time data for any article within the past X years
-    max_article_age: int
-
     def __init__(
         self, snowplow_fields: Set[str], scrape_config: ScrapeConfig, training_params: TrainParamsCF, max_article_age
     ):
-        self.snowplow_fields = snowplow_fields
-        self.scrape_config = scrape_config
-        self.training_params = training_params
-        self.max_article_age = max_article_age
+        super().__init__(model_type=ModelType.ARTICLE)
 
-    def fetch_data(self, site: Site, interactions_data: pd.DataFrame = None, experiment_time=None):
-        self.interactions_data = interactions_data
-        self.experiment_time = experiment_time
+        # Parameters
+        self.snowplow_fields: Set[str] = snowplow_fields
+        self.scrape_config: ScrapeConfig = scrape_config
+        self.training_params: TrainParamsCF = training_params
+        # this is a number of years; will grab dwell time data for any article within the past X years
+        self.max_article_age: int = max_article_age
+
+    def fetch_data(self, site: Site, interactions_data: pd.DataFrame = None):
+        self.train_data = interactions_data
+        self.site = site
         pass
 
-    def preprocess_data(self, site: Site):
+    def preprocess_data(self):
         pass
 
     def generate_embeddings(self):
-        model = Trainer(self.interactions_data, self.experiment_time, _spotlight_transform, self.training_params)
+        model = Trainer(self.train_data, self.experiment_time, _spotlight_transform, self.training_params)
         model.fit()
         self.train_embeddings = model.model_embeddings
         self.decays = model.model_dates_df["date_decays"].values

--- a/job/strategies/collaborative_filtering.py
+++ b/job/strategies/collaborative_filtering.py
@@ -6,7 +6,6 @@ from db.mappings.model import ModelType
 from job.strategies.collaborative_filter.train_model import _spotlight_transform
 from job.strategies.collaborative_filter.trainer import Trainer
 from job.strategies.templates.strategy import Strategy
-from sites.templates.site import Site
 
 
 class ScrapeConfig(TypedDict):
@@ -50,10 +49,8 @@ class CollaborativeFiltering(Strategy):
         # this is a number of years; will grab dwell time data for any article within the past X years
         self.max_article_age: int = max_article_age
 
-    def fetch_data(self, site: Site, interactions_data: pd.DataFrame = None):
+    def fetch_data(self, interactions_data: pd.DataFrame = None):
         self.train_data = interactions_data
-        self.site = site
-        pass
 
     def preprocess_data(self):
         pass

--- a/job/strategies/popularity.py
+++ b/job/strategies/popularity.py
@@ -1,16 +1,15 @@
-from dataclasses import dataclass
-from typing import Any, Dict, List
+from datetime import datetime
 
-import numpy as np
 import pandas as pd
 
+from db.helpers import refresh_db
 from db.mappings.model import ModelType
-from db.mappings.recommendation import Rec
+from job.helpers import warehouse
+from job.strategies.save_defaults import save_defaults
 from job.strategies.templates.strategy import Strategy
 from sites.templates.site import Site
 
 
-@dataclass
 class Popularity(Strategy):
     """
     Default popularity-model site configs and methods.
@@ -18,20 +17,30 @@ class Popularity(Strategy):
 
     # this is a number of days; will only recommend articles within the past X days
     popularity_window: int
+    top_articles: pd.DataFrame
+    experiment_time: datetime
+    model_type: ModelType = ModelType.POPULARITY
 
-    def fetch_data(self, site: Site, interactions_data: pd.DataFrame) -> List[Dict[str, Any]]:
+    def __init__(self, popularity_window: int):
+        self.popularity_window = popularity_window
+
+    def fetch_data(self, site: Site, interactions_data: pd.DataFrame = None, experiment_time=None) -> None:
+        self.site = site
+        self.experiment_time = experiment_time
+        self.top_articles = warehouse.get_default_recs(site=site)
+
+    def preprocess_data(self) -> None:
         pass
 
-    def preprocess_data(
-        self, site: Site, article_data: List[Dict[str, str]], interactions_data: pd.DataFrame
-    ) -> pd.DataFrame:
+    def generate_embeddings(self) -> None:
         pass
 
-    def generate_embeddings(self, train_data: pd.DataFrame) -> np.ndarray:
+    def generate_recommendations(self) -> None:
+        """
+        Run article-level embeddings through a KNN and create recs from resulting neighbors.
+        """
         pass
 
-    def generate_recommendations(self, train_embeddings: np.ndarray, train_data: pd.DataFrame) -> List[Rec]:
-        pass
-
-    def save_recommendations(self, site: Site, recs: List[Rec], model_type: ModelType) -> None:
-        pass
+    @refresh_db
+    def save_recommendations(self, site: Site) -> None:
+        save_defaults(self.top_articles, site, self.experiment_time)

--- a/job/strategies/popularity.py
+++ b/job/strategies/popularity.py
@@ -1,11 +1,5 @@
-from datetime import datetime
-
 import pandas as pd
 
-from db.helpers import refresh_db
-from db.mappings.model import ModelType
-from job.helpers import warehouse
-from job.strategies.save_defaults import save_defaults
 from job.strategies.templates.strategy import Strategy
 from sites.templates.site import Site
 
@@ -15,32 +9,15 @@ class Popularity(Strategy):
     Default popularity-model site configs and methods.
     """
 
-    # this is a number of days; will only recommend articles within the past X days
-    popularity_window: int
-    top_articles: pd.DataFrame
-    experiment_time: datetime
-    model_type: ModelType = ModelType.POPULARITY
+    def __init__(self, popularity_window):
+        # this is a number of days; will only recommend articles within the past X days
+        self.popularity_window: int = popularity_window
 
-    def __init__(self, popularity_window: int):
-        self.popularity_window = popularity_window
-
-    def fetch_data(self, site: Site, interactions_data: pd.DataFrame = None, experiment_time=None) -> None:
-        self.site = site
-        self.experiment_time = experiment_time
-        self.top_articles = warehouse.get_default_recs(site=site)
+    def fetch_data(self, site: Site, interactions_data: pd.DataFrame = None) -> None:
+        pass
 
     def preprocess_data(self) -> None:
         pass
 
     def generate_embeddings(self) -> None:
         pass
-
-    def generate_recommendations(self) -> None:
-        """
-        Run article-level embeddings through a KNN and create recs from resulting neighbors.
-        """
-        pass
-
-    @refresh_db
-    def save_recommendations(self, site: Site) -> None:
-        save_defaults(self.top_articles, site, self.experiment_time)

--- a/job/strategies/popularity.py
+++ b/job/strategies/popularity.py
@@ -1,7 +1,6 @@
 import pandas as pd
 
 from job.strategies.templates.strategy import Strategy
-from sites.templates.site import Site
 
 
 class Popularity(Strategy):
@@ -13,7 +12,7 @@ class Popularity(Strategy):
         # this is a number of days; will only recommend articles within the past X days
         self.popularity_window: int = popularity_window
 
-    def fetch_data(self, site: Site, interactions_data: pd.DataFrame = None) -> None:
+    def fetch_data(self, interactions_data: pd.DataFrame = None) -> None:
         pass
 
     def preprocess_data(self) -> None:

--- a/job/strategies/semantic_similarity.py
+++ b/job/strategies/semantic_similarity.py
@@ -9,7 +9,6 @@ from sklearn.preprocessing import normalize
 from db.mappings.model import ModelType
 from job.strategies.templates.strategy import Strategy
 from lib.config import config
-from sites.templates.site import Site
 
 # TODO: When adding functions to job.py in the future, maybe move these job.py and pass to respective functions as a
 #  parameter?
@@ -28,11 +27,10 @@ class SemanticSimilarity(Strategy):
         self.interactions_data: Optional[pd.DataFrame] = None
         self.PRETRAINED_MODEL_NAME = config.get("SS_ENCODER")
 
-    def fetch_data(self, site: Site, interactions_data: pd.DataFrame = None):
+    def fetch_data(self, interactions_data: pd.DataFrame = None):
         """
         Fetch data of all articles included in the interactions table.
         """
-        self.site = site
         self.interactions_data = interactions_data
         # Grab unique external IDs from Interactions table
         # https://stackoverflow.com/questions/46839277/series-unique-vs-list-of-set-performance

--- a/job/strategies/semantic_similarity.py
+++ b/job/strategies/semantic_similarity.py
@@ -1,24 +1,18 @@
 import logging
-import time
-from typing import Any, Dict, List
+from typing import Dict, List
 
 import numpy as np
 import pandas as pd
 from sentence_transformers import SentenceTransformer
 from sklearn.preprocessing import normalize
 
-from db.helpers import create_model, refresh_db, set_current_model
 from db.mappings.model import ModelType
-from db.mappings.recommendation import Rec
-from job.helpers.itertools import batch
-from job.helpers.knn import KNN, map_neighbors_to_recommendations
 from job.strategies.templates.strategy import Strategy
 from lib.config import config
 from sites.templates.site import Site
 
 # TODO: When adding functions to job.py in the future, maybe move these job.py and pass to respective functions as a parameter?
 PRETRAINED_MODEL_NAME = config.get("SS_ENCODER")
-MAX_RECS = config.get("MAX_RECS")
 
 
 class SemanticSimilarity(Strategy):
@@ -26,10 +20,15 @@ class SemanticSimilarity(Strategy):
     Semantic-Similarity site configs and methods.
     """
 
-    def fetch_data(self, site: Site, interactions_data: pd.DataFrame) -> List[Dict[str, Any]]:
+    interactions_data: pd.DataFrame = None
+    article_data: List[Dict[str, str]] = None
+    model_type: ModelType = ModelType.SEMANTIC_SIMILARITY
+
+    def fetch_data(self, site: Site, interactions_data: pd.DataFrame = None, experiment_time=None):
         """
         Fetch data of all articles included in the interactions table.
         """
+        self.interactions_data = interactions_data
         # Grab unique external IDs from Interactions table
         # https://stackoverflow.com/questions/46839277/series-unique-vs-list-of-set-performance
         external_ids: List[str] = list(set(interactions_data["external_id"]))
@@ -43,11 +42,9 @@ class SemanticSimilarity(Strategy):
         if num_to_fetch != num_fetched:
             logging.warning(f"No. articles fetched ({num_fetched}) doesn't match no. articles to fetch ({num_to_fetch}).")
 
-        return data
+        self.article_data = data
 
-    def preprocess_data(
-        self, site: Site, article_data: List[Dict[str, str]], interactions_data: pd.DataFrame
-    ) -> pd.DataFrame:
+    def preprocess_data(self, site: Site):
         """
         Preprocess fetched data into a DataFrame ready for training. Steps include:
         - Get a text representation for each article. The rule for creating such representations may differ between sites.
@@ -55,12 +52,13 @@ class SemanticSimilarity(Strategy):
         """
         # Create text representation of each article
         data = [
-            {"external_id": article["external_id"], "text": site.get_article_text(article)} for article in article_data
+            {"external_id": article["external_id"], "text": site.get_article_text(article)}
+            for article in self.article_data
         ]
         df_data = pd.DataFrame(data, dtype=str)
 
         # Extract article metadata (LNL DB article ID, categorial item ID, publish date) from interactions_data
-        df_metadata = interactions_data[["article_id", "external_id", "published_at"]].dropna().drop_duplicates()
+        df_metadata = self.interactions_data[["article_id", "external_id", "published_at"]].dropna().drop_duplicates()
 
         # Merge article metadata with article text representations; the result is a DataFrame with 4 columns:
         # article_id, external_id, published_at and text.
@@ -68,64 +66,15 @@ class SemanticSimilarity(Strategy):
         # it, maybe with something like pandera (https://stackoverflow.com/questions/61386477/type-hints-for-a-pandas-dataframe-with-mixed-dtypes)?
         df = df_metadata.merge(df_data, how="inner", on="external_id")
 
-        return df
+        self.train_data = df
 
-    def generate_embeddings(self, train_data: pd.DataFrame) -> np.ndarray:
+    def generate_embeddings(self) -> None:
         """
         Given article data DataFrame with a text column, create article-level text embeddings.
         """
-        texts = train_data["text"].tolist()
+        texts = self.train_data["text"].tolist()
         model = SentenceTransformer(PRETRAINED_MODEL_NAME, device="cpu")
 
-        return model.encode(texts, convert_to_numpy=True)
-
-    def generate_recommendations(self, train_embeddings: np.ndarray, train_data: pd.DataFrame) -> List[Rec]:
-        """
-        Run article-level embeddings through a KNN and create recs from resulting neighbors.
-        """
-        embeddings_normalized = normalize(train_embeddings, axis=1, norm="l2")
+        self.train_embeddings = normalize(model.encode(texts, convert_to_numpy=True), axis=1, norm="l2")
         # TODO: Not doing time decay on SS for time being
-        decays = np.ones(embeddings_normalized.shape[0])
-        searcher = KNN(embeddings_normalized, decays)
-
-        logging.info("Calculating KNN...")
-        start_ts = time.time()
-
-        # MAX_RECS + 1 because an article's top match is always itself
-        similarities, nearest_indices = searcher.get_similar_indices(MAX_RECS + 1)
-
-        logging.info(f"Total latency to find K-Nearest Neighbors: {time.time() - start_ts}")
-
-        return map_neighbors_to_recommendations(
-            model_item_ids=train_data["external_id"].factorize()[0],
-            external_ids=train_data["external_id"].values,
-            article_ids=train_data["article_id"].values,
-            model_item_neighbor_indices=nearest_indices,
-            similarities=similarities,
-        )
-
-    @refresh_db
-    def save_recommendations(self, site: Site, recs: List[Rec], model_type: ModelType) -> None:
-        """
-        Save generated recommendations to database.
-        """
-        start_ts = time.time()
-        # Create new model object in DB
-        model_id = create_model(type=model_type.value, site=site.name)
-        logging.info(f"Created model with id {model_id}")
-        for rec in recs:
-            rec.model_id = model_id
-
-        logging.info(f"Writing {len(recs)} recommendations...")
-        # Insert a small delay to avoid overwhelming the DB
-        for rec_batch in batch(recs, n=50):
-            Rec.bulk_create(rec_batch)
-            time.sleep(0.05)
-
-        logging.info(f"Updaing model objects in DB")
-        set_current_model(model_id, model_type, site.name)
-
-        latency = time.time() - start_ts
-        # TODO: Unlike save_predictions in CF, not writing metrics to CloudWatch for now
-        logging.info(f"rec_creation_time: {latency}s")
-        logging.info(f"recs_creation_total: {len(recs)}")
+        self.decays = np.ones(self.train_embeddings.shape[0])

--- a/job/strategies/semantic_similarity.py
+++ b/job/strategies/semantic_similarity.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 import numpy as np
 import pandas as pd
@@ -11,8 +11,8 @@ from job.strategies.templates.strategy import Strategy
 from lib.config import config
 from sites.templates.site import Site
 
-# TODO: When adding functions to job.py in the future, maybe move these job.py and pass to respective functions as a parameter?
-PRETRAINED_MODEL_NAME = config.get("SS_ENCODER")
+# TODO: When adding functions to job.py in the future, maybe move these job.py and pass to respective functions as a
+#  parameter?
 
 
 class SemanticSimilarity(Strategy):
@@ -20,39 +20,47 @@ class SemanticSimilarity(Strategy):
     Semantic-Similarity site configs and methods.
     """
 
-    interactions_data: pd.DataFrame = None
-    article_data: List[Dict[str, str]] = None
-    model_type: ModelType = ModelType.SEMANTIC_SIMILARITY
+    def __init__(self):
+        super().__init__(model_type=ModelType.SEMANTIC_SIMILARITY)
 
-    def fetch_data(self, site: Site, interactions_data: pd.DataFrame = None, experiment_time=None):
+        # Other attributes
+        self.article_data: Optional[List[Dict[str, str]]] = None
+        self.interactions_data: Optional[pd.DataFrame] = None
+        self.PRETRAINED_MODEL_NAME = config.get("SS_ENCODER")
+
+    def fetch_data(self, site: Site, interactions_data: pd.DataFrame = None):
         """
         Fetch data of all articles included in the interactions table.
         """
+        self.site = site
         self.interactions_data = interactions_data
         # Grab unique external IDs from Interactions table
         # https://stackoverflow.com/questions/46839277/series-unique-vs-list-of-set-performance
         external_ids: List[str] = list(set(interactions_data["external_id"]))
 
         # Fetch article text data using said IDs
-        data = site.bulk_fetch_by_external_id(external_ids)
+        data = self.site.bulk_fetch_by_external_id(external_ids)
 
         # Validation: check if all external IDs have been fetched
         num_to_fetch = len(external_ids)
         num_fetched = len(data)
         if num_to_fetch != num_fetched:
-            logging.warning(f"No. articles fetched ({num_fetched}) doesn't match no. articles to fetch ({num_to_fetch}).")
+            logging.warning(
+                f"No. articles fetched ({num_fetched}) doesn't match no. articles" f" to fetch ({num_to_fetch})."
+            )
 
         self.article_data = data
 
-    def preprocess_data(self, site: Site):
+    def preprocess_data(self):
         """
         Preprocess fetched data into a DataFrame ready for training. Steps include:
-        - Get a text representation for each article. The rule for creating such representations may differ between sites.
+        - Get a text representation for each article. The rule for creating such representations
+        may differ between sites.
         - Merge fetched data with article metadata (LNL DB article ID, etc.)
         """
         # Create text representation of each article
         data = [
-            {"external_id": article["external_id"], "text": site.get_article_text(article)}
+            {"external_id": article["external_id"], "text": self.site.get_article_text(article)}
             for article in self.article_data
         ]
         df_data = pd.DataFrame(data, dtype=str)
@@ -61,9 +69,9 @@ class SemanticSimilarity(Strategy):
         df_metadata = self.interactions_data[["article_id", "external_id", "published_at"]].dropna().drop_duplicates()
 
         # Merge article metadata with article text representations; the result is a DataFrame with 4 columns:
-        # article_id, external_id, published_at and text.
-        # TODO: The schema for df will only include these 4 columns, which means we would benefit from type-enforcing
-        # it, maybe with something like pandera (https://stackoverflow.com/questions/61386477/type-hints-for-a-pandas-dataframe-with-mixed-dtypes)?
+        # article_id, external_id, published_at and text. TODO: The schema for df will only include these 4 columns,
+        #  which means we would benefit from type-enforcing it, maybe with something like pandera (
+        #  https://stackoverflow.com/questions/61386477/type-hints-for-a-pandas-dataframe-with-mixed-dtypes)?
         df = df_metadata.merge(df_data, how="inner", on="external_id")
 
         self.train_data = df
@@ -73,7 +81,7 @@ class SemanticSimilarity(Strategy):
         Given article data DataFrame with a text column, create article-level text embeddings.
         """
         texts = self.train_data["text"].tolist()
-        model = SentenceTransformer(PRETRAINED_MODEL_NAME, device="cpu")
+        model = SentenceTransformer(self.PRETRAINED_MODEL_NAME, device="cpu")
 
         self.train_embeddings = normalize(model.encode(texts, convert_to_numpy=True), axis=1, norm="l2")
         # TODO: Not doing time decay on SS for time being

--- a/job/strategies/templates/strategy.py
+++ b/job/strategies/templates/strategy.py
@@ -1,16 +1,24 @@
 from __future__ import annotations
 
+import logging
+import time
 from abc import ABCMeta, abstractmethod
-from typing import TYPE_CHECKING, Any, Dict, List
+from typing import TYPE_CHECKING, List
 
 import numpy as np
 import pandas as pd
 
+from db.helpers import create_model, refresh_db, set_current_model
 from db.mappings.model import ModelType
 from db.mappings.recommendation import Rec
+from job.helpers.itertools import batch
+from job.helpers.knn import KNN, map_neighbors_to_recommendations
+from lib.config import config
 
 if TYPE_CHECKING:
     from sites.templates.site import Site
+
+MAX_RECS = config.get("MAX_RECS")
 
 
 class Strategy(metaclass=ABCMeta):
@@ -19,39 +27,77 @@ class Strategy(metaclass=ABCMeta):
     popularity, semantic similarity).
     """
 
+    decays: np.ndarray
+    train_embeddings: np.ndarray
+    recommendations: List[Rec]
+    model_type: ModelType = None
+    train_data: pd.DataFrame = None
+
     @abstractmethod
-    def fetch_data(self, site: Site, interactions_data: pd.DataFrame) -> List[Dict[str, Any]]:
+    def fetch_data(self, site: Site, interactions_data: pd.DataFrame = None, experiment_time=None) -> None:
         """
         Fetch data from the data warehouse
         """
         pass
 
     @abstractmethod
-    def preprocess_data(
-        self, site: Site, article_data: List[Dict[str, str]], interactions_data: pd.DataFrame
-    ) -> pd.DataFrame:
+    def preprocess_data(self, site: Site) -> None:
         """
         Preprocess fetched data into a DataFrame ready for training.
         """
         pass
 
     @abstractmethod
-    def generate_embeddings(self, train_data: pd.DataFrame) -> np.ndarray:
+    def generate_embeddings(self) -> None:
         """
         Given DataFrame with training data, create embeddings.
         """
         pass
 
-    @abstractmethod
-    def generate_recommendations(self, train_embeddings: np.ndarray, train_data: pd.DataFrame) -> List[Rec]:
+    def generate_recommendations(self) -> None:
         """
         Run article-level embeddings through a KNN and create recs from resulting neighbors.
         """
-        pass
+        searcher = KNN(self.train_embeddings, self.decays)
 
-    @abstractmethod
-    def save_recommendations(self, site: Site, recs: List[Rec], model_type: ModelType) -> None:
+        logging.info("Calculating KNN...")
+        start_ts = time.time()
+
+        # MAX_RECS + 1 because an article's top match is always itself
+        similarities, nearest_indices = searcher.get_similar_indices(MAX_RECS + 1)
+
+        logging.info(f"Total latency to find K-Nearest Neighbors: {time.time() - start_ts}")
+
+        self.recommendations = map_neighbors_to_recommendations(
+            model_item_ids=self.train_data["external_id"].factorize()[0],
+            external_ids=self.train_data["external_id"].values,
+            article_ids=self.train_data["article_id"].values,
+            model_item_neighbor_indices=nearest_indices,
+            similarities=similarities,
+        )
+
+    @refresh_db
+    def save_recommendations(self, site: Site) -> None:
         """
         Save generated recommendations to database.
         """
-        pass
+        start_ts = time.time()
+        # Create new model object in DB
+        model_id = create_model(type=self.model_type.value, site=site.name)
+        logging.info(f"Created model with id {model_id}")
+        for rec in self.recommendations:
+            rec.model_id = model_id
+
+        logging.info(f"Writing {len(self.recommendations)} recommendations...")
+        # Insert a small delay to avoid overwhelming the DB
+        for rec_batch in batch(self.recommendations, n=50):
+            Rec.bulk_create(rec_batch)
+            time.sleep(0.05)
+
+        logging.info(f"Updating model objects in DB")
+        set_current_model(model_id, self.model_type, site.name)
+
+        latency = time.time() - start_ts
+        # TODO: Unlike save_predictions in CF, not writing metrics to CloudWatch for now
+        logging.info(f"rec_creation_time: {latency}s")
+        logging.info(f"recs_creation_total: {len(self.recommendations)}")

--- a/job/strategies/templates/strategy.py
+++ b/job/strategies/templates/strategy.py
@@ -34,17 +34,36 @@ class Strategy(metaclass=ABCMeta):
         Constructor that needs to be defined by subclasses
         """
         self.model_type = model_type
-        self.experiment_time: datetime = datetime.now()
+        self.site: Optional[Site] = None
+        self.experiment_time: datetime = None
 
         # Attributes to be defined in subclasses; listing them here to keep track
         self.decays: Optional[np.ndarray] = None
         self.train_embeddings: Optional[np.ndarray] = None
         self.train_data: Optional[pd.DataFrame] = None
         self.recommendations: Optional[List[Rec]] = None
-        self.site: Optional[Site] = None
+
+    def set_experiment_time(self, experiment_time: datetime) -> None:
+        """
+        Set experiment time post-init but pre-fetch_data and other methods
+        """
+        self.experiment_time = experiment_time
+
+    def set_site(self, site: Site) -> None:
+        """
+        Set site post-init but pre-fetch_data and other methods
+        """
+        self.site = site
+
+    def prepare(self, site: Site, experiment_time: datetime) -> None:
+        """
+        Prepare instance post-init but pre-fetch_data and other methods
+        """
+        self.set_site(site)
+        self.set_experiment_time(experiment_time)
 
     @abstractmethod
-    def fetch_data(self, site: Site, interactions_data: pd.DataFrame = None) -> None:
+    def fetch_data(self, interactions_data: pd.DataFrame = None) -> None:
         """
         Fetch data from the data warehouse
         """


### PR DESCRIPTION
### Description

This PR translates the existing code for collaborative filtering into the new class hierarchy that we created. In addition to that, it makes adjustments in subclass `SemanticSimilarity` to make it compatible with `Strategy` and `CollaborativeFiltering`. Finally, it also fleshes out the routines for `Popularity`.

None of the previous routines for collaborative filtering has been changed. They are called from inside the new code.

Only two files outside the `Strategy` hierarchy have been tweaked:

- [`db/helpers.py`](https://github.com/LocalAtBrown/article-rec-training-job/blob/refactor-collaborative-filtering/db/helpers.py): to prevent a circular import
- [`db/mappings/model.py`](https://github.com/LocalAtBrown/article-rec-training-job/blob/refactor-collaborative-filtering/db/mappings/model.py): to add a new model called SEMANTIC_SIMILARITY

### Testing

All tests passed.