### PR TITLE
Incrase PI popularity window to 2 days

### DIFF
--- a/sites/philadelphia_inquirer.py
+++ b/sites/philadelphia_inquirer.py
@@ -22,7 +22,7 @@ ARC API documentation
 https://www.notion.so/a8698dd6527140aaba8acfc29be40aa8?v=d30e06f348e94063ab4f451a345bb0d2&p=209fa6fada864bc0a1555622bb559181
 """
 
-POPULARITY_WINDOW = 1
+POPULARITY_WINDOW = 2
 MAX_ARTICLE_AGE = 2
 DOMAIN = "www.inquirer.com"
 NAME = "philadelphia-inquirer"


### PR DESCRIPTION
## Description

Simple fix for the empty DataFrame returned by `warehouse.get_default_recs` at the 00:00 UTC mark.