### PR TITLE
Increase TT default popularity window to 14 days

### DIFF
--- a/sites/texas_tribune.py
+++ b/sites/texas_tribune.py
@@ -22,7 +22,7 @@ TT API documentation
 https://www.notion.so/a8698dd6527140aaba8acfc29be40aa8?v=d30e06f348e94063ab4f451a345bb0d2&p=209fa6fada864bc0a1555622bb559181
 """
 
-POPULARITY_WINDOW = 7
+POPULARITY_WINDOW = 14
 MAX_ARTICLE_AGE = 10
 DOMAIN = "www.texastribune.org"
 NAME = "texas-tribune"


### PR DESCRIPTION
## Description

There was a problem with the Snowplow collection pipeline that made Texas Tribune events unable to flow into enriched S3 buckets since May 27 (7 days ago), throwing off the default-recs calculation. Temporarily increases Texas Tribune popularity window to 14 days to ward off CloudWatch errors until we can fix this problem.