### PR TITLE
Limit WCP cron to once a day

### DIFF
--- a/cdk/lib/app-stack.ts
+++ b/cdk/lib/app-stack.ts
@@ -16,7 +16,7 @@ export interface AppStackProps extends cdk.StackProps {
   logGroup: ILogGroup;
 }
 
-function getCron(stage: helpers.STAGE, index: number) {
+function getCron(stage: helpers.STAGE, site: helpers.Organization, index: number) {
   let n = partners.filter(f => f.enabled).length
   // Offset the jobs evenly across 1 hour.
   // Cron makes it really hard to do more complicated scheduling than that
@@ -24,7 +24,7 @@ function getCron(stage: helpers.STAGE, index: number) {
 
   return {
     minute: `${offset}`,
-    hour: '0,2,4,6,8,10,12,14,16,18,20,22',
+    hour: `${site.cronHours.join(",")}`,
   }
 }
 
@@ -113,7 +113,7 @@ export class AppStack extends cdk.Stack {
     new ScheduledFargateTask(this, `${id}ScheduledFargateTask`, {
       // find more cron scheduling options here:
       // https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-events.CronOptions.html
-      schedule: Schedule.cron(getCron(props.stage, props.index)),
+      schedule: Schedule.cron(getCron(props.stage, props.site, props.index)),
       desiredTaskCount: 1,
       cluster,
       subnetSelection: { subnetType: ec2.SubnetType.PUBLIC },

--- a/cdk/lib/helpers.ts
+++ b/cdk/lib/helpers.ts
@@ -37,6 +37,7 @@ export function getResourceName(stage: STAGE, resource: RESOURCE): string {
  * @param {number} cpu vCPUs for the training job
  * @param {number} memoryLimitMiB max memory for the training job
  * @param {boolean} enabled is the job enabled?
+ * @param {number[]} cronHours hours to run the job
  */
 export interface Organization {
   orgName: string,
@@ -44,6 +45,7 @@ export interface Organization {
   cpu: number,
   memoryLimitMiB: number,
   enabled: boolean,
+  cronHours: number[],
 }
 
 

--- a/cdk/lib/partners.ts
+++ b/cdk/lib/partners.ts
@@ -4,6 +4,7 @@ import { Organization } from "./helpers"
 // https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html
 const DEFAULT_CPU = 2048;
 const DEFAULT_MEM = 8192;
+const DEFAULT_CRON_HOURS = [0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22];
 
 export const partners: Array<Organization> = [
   {
@@ -12,6 +13,7 @@ export const partners: Array<Organization> = [
     cpu: DEFAULT_CPU,
     memoryLimitMiB: DEFAULT_MEM,
     enabled: true,
+    cronHours: [6], // 6 AM UTC = 2 AM EST, run once a day, during the night, until WCP is ready to run more often
   },
   {
     orgName: "texas-tribune",
@@ -19,6 +21,7 @@ export const partners: Array<Organization> = [
     cpu: DEFAULT_CPU,
     memoryLimitMiB: DEFAULT_MEM,
     enabled: true,
+    cronHours: DEFAULT_CRON_HOURS,
   },
   {
     orgName: "philadelphia-inquirer",
@@ -26,5 +29,6 @@ export const partners: Array<Organization> = [
     cpu: DEFAULT_CPU,
     memoryLimitMiB: 16384,
     enabled: true,
+    cronHours: DEFAULT_CRON_HOURS,
   },
 ]

--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "cdk",
       "version": "0.1.0",
       "dependencies": {
         "@aws-cdk/aws-codebuild": "^1.66.0",


### PR DESCRIPTION
## Description

Temporarily reduce WCP job runs to once a day, at 6 AM UTC, until WCP is ready to resume usual schedule.

```bash
❯ cdk1 diff WashingtonCityPaperArticleRecTrainingJob
Including dependency stacks: ArticleRecTrainingJobCentralResourcesStack
Stack ArticleRecTrainingJobCentralResourcesStack
There were no differences
Stack WashingtonCityPaperArticleRecTrainingJob
Resources
[~] AWS::ECS::TaskDefinition WashingtonCityPaperArticleRecTrainingJobTaskDefinition WashingtonCityPaperArticleRecTrainingJobTaskDefinitionECBC0787 replace
 └─ [~] ContainerDefinitions (requires replacement)
     └─ @@ -24,7 +24,7 @@
        [ ]       {
        [ ]         "Ref": "AWS::URLSuffix"
        [ ]       },
        [-]       "/aws-cdk/assets:4d3c19e2698d4ba227e54c029d176200174d974c369d6b299f6c942b0e5ac69e"
        [+]       "/aws-cdk/assets:6779cec73101f137b434a5874e7e53ee4621d79fd6f6b0269fd5681b9f9f8838"
        [ ]     ]
        [ ]   ]
        [ ] },
[~] AWS::Events::Rule WashingtonCityPaperArticleRecTrainingJobScheduledFargateTask/ScheduledEventRule WashingtonCityPaperArticleRecTrainingJobScheduledFargateTaskScheduledEventRuleB8565E36 
 └─ [~] ScheduleExpression
     ├─ [-] cron(0 0,2,4,6,8,10,12,14,16,18,20,22 * * ? *)
     └─ [+] cron(0 6 * * ? *)
```