### PR TITLE
Increase WCP's window to fetch raw events

### DIFF
--- a/env.json
+++ b/env.json
@@ -12,7 +12,6 @@
         "DISPLAY_PROGRESS": false,
         "MAX_RECS": 10,
         "DAYS_OF_DATA": 28,
-        "HOURS_OF_DATA": 2,
         "REDSHIFT_DB_NAME": "/prod/redshift-db/name",
         "REDSHIFT_DB_PASSWORD": "/prod/redshift-db/password",
         "REDSHIFT_DB_USER": "/prod/redshift-db/user",

--- a/job/job.py
+++ b/job/job.py
@@ -16,13 +16,13 @@ from lib.metrics import Unit, write_metric
 from sites.site import Site
 
 
-def fetch_and_upload_data(site: Site, dt: datetime, hours=config.get("HOURS_OF_DATA")):
+def fetch_and_upload_data(site: Site, dt: datetime):
     """
     1. Upload transformed events data to Redshift
     2. Update article metadata
     3. Update dwell times table
     """
-    dts = [dt - timedelta(hours=i) for i in range(hours)]
+    dts = [dt - timedelta(hours=i) for i in range(site.hours_of_data)]
 
     fetch_data.fetch_transform_upload_chunks(site, dts)
     scrape_metadata.scrape_upload_metadata(site, dts)

--- a/job/steps/scrape_metadata.py
+++ b/job/steps/scrape_metadata.py
@@ -28,7 +28,6 @@ EXCLUDE_FAILURE_TYPES = {
 }
 
 
-# @refresh_db
 def scrape_upload_metadata(site: Site, dts: List[datetime]) -> Tuple[List[Article], List[ArticleScrapingError]]:
     """
     Update article metadata for any URLs that were visited during the given dts.

--- a/sites/philadelphia_inquirer.py
+++ b/sites/philadelphia_inquirer.py
@@ -24,6 +24,7 @@ https://www.notion.so/a8698dd6527140aaba8acfc29be40aa8?v=d30e06f348e94063ab4f451
 
 POPULARITY_WINDOW = 2
 MAX_ARTICLE_AGE = 2
+HOURS_OF_DATA = 2
 DOMAIN = "www.inquirer.com"
 NAME = "philadelphia-inquirer"
 FIELDS = GOOGLE_TAG_MANAGER_RAW_FIELDS
@@ -269,6 +270,7 @@ def fetch_article(external_id: str, path: str) -> Response:
 PI_SITE = Site(
     NAME,
     FIELDS,
+    HOURS_OF_DATA,
     TRAINING_PARAMS,
     SCRAPE_CONFIG,
     transform_data_google_tag_manager,

--- a/sites/site.py
+++ b/sites/site.py
@@ -5,6 +5,7 @@ Site = namedtuple(
     [
         "name",
         "fields",
+        "hours_of_data",
         "training_params",
         "scrape_config",
         "transform_raw_data",

--- a/sites/texas_tribune.py
+++ b/sites/texas_tribune.py
@@ -24,6 +24,7 @@ https://www.notion.so/a8698dd6527140aaba8acfc29be40aa8?v=d30e06f348e94063ab4f451
 
 POPULARITY_WINDOW = 7
 MAX_ARTICLE_AGE = 10
+HOURS_OF_DATA = 2
 DOMAIN = "www.texastribune.org"
 NAME = "texas-tribune"
 FIELDS = GOOGLE_TAG_MANAGER_RAW_FIELDS
@@ -200,6 +201,7 @@ def fetch_article(
 TT_SITE = Site(
     NAME,
     FIELDS,
+    HOURS_OF_DATA,
     TRAINING_PARAMS,
     SCRAPE_CONFIG,
     transform_data_google_tag_manager,

--- a/sites/washington_city_paper.py
+++ b/sites/washington_city_paper.py
@@ -18,6 +18,7 @@ from sites.site import Site
 
 POPULARITY_WINDOW = 7
 MAX_ARTICLE_AGE = 10
+HOURS_OF_DATA = 24
 DOMAIN = "washingtoncitypaper.com"
 NAME = "washington-city-paper"
 FIELDS = GOOGLE_TAG_MANAGER_RAW_FIELDS
@@ -130,6 +131,7 @@ def fetch_article(external_id: str, path: str) -> Response:
 WCP_SITE = Site(
     NAME,
     FIELDS,
+    HOURS_OF_DATA,
     TRAINING_PARAMS,
     SCRAPE_CONFIG,
     transform_data_google_tag_manager,


### PR DESCRIPTION
## Description

Increases `HOURS_OF_DATA` for WCP from 2 hours to 24 hours to reflect the once-a-day schedule change (see #179). To accommodate this, move `HOURS_OF_DATA` from global config to site config.

## Testing

All tests passed.