### PR TITLE
Add option to force-update in Postgres page writer

### DIFF
--- a/app.py
+++ b/app.py
@@ -122,7 +122,10 @@ def create_page_writer_factory_dict(config: Config) -> dict[PageWriterType, Call
         engine = create_engine(db_url)
         sa_session_factory = sessionmaker(bind=engine)
 
-        return PostgresBasePageWriter(sa_session_factory=sa_session_factory)
+        return PostgresBasePageWriter(
+            sa_session_factory=sa_session_factory,
+            force_update_despite_latest=config_component.params.get("force_update_despite_latest", False),
+        )
 
     return {
         PageWriterType.POSTGRES_BASE: factory_postgres,

--- a/article_rec_training_job/components/page_writers/postgres.py
+++ b/article_rec_training_job/components/page_writers/postgres.py
@@ -19,7 +19,14 @@ class BaseWriter:
     whose tables are defined by the article-rec-db package.
     """
 
+    # SQLA sessionmaker
     sa_session_factory: sessionmaker[Session]
+
+    # Whether or not to force-update articles even if the site_updated_at
+    # field is not changing. This is useful when we make changes to the database
+    # schema (e.g., adding new columns to the article table) and want to force
+    # an update during backfilling to populate data in all existing articles.
+    force_update_despite_latest: bool
 
     num_new_pages_written: int = field(init=False, repr=False)
     num_pages_ignored: int = field(init=False, repr=False)
@@ -62,6 +69,18 @@ class BaseWriter:
             statement_write_articles = insert(Article).values(
                 [{**page.article.model_dump(), "page_id": dict_page_url_to_id[page.url]} for page in pages_article]  # type: ignore
             )
+            # Obviously, we don't want to update an article if there's nothing new to update,
+            # so we're relying on the site_updated_at field to determine whether or not to update
+            condition_upsert_articles = (
+                # If the site_updated_at field is changing from None to a timestamp, we update.
+                (Article.site_updated_at == None)  # type: ignore  # noqa: E711
+                & (statement_write_articles.excluded.site_updated_at != None)  # noqa: E711
+            ) | (
+                # If the site_updated_at field is changing from a timestamp to a newer timestamp, we also update.
+                (Article.site_updated_at != None)  # type: ignore  # noqa: E711
+                & (statement_write_articles.excluded.site_updated_at != None)  # noqa: E711
+                & (Article.site_updated_at < statement_write_articles.excluded.site_updated_at)
+            )
             statement_write_articles = statement_write_articles.on_conflict_do_update(
                 index_elements=[Article.site, Article.id_in_site],
                 set_={
@@ -73,21 +92,8 @@ class BaseWriter:
                     "is_in_house_content": statement_write_articles.excluded.is_in_house_content,
                     "db_updated_at": datetime.utcnow(),
                 },
-                # Obviously, we don't want to update an article if there's nothing new to update,
-                # so we're relying on the site_updated_at field to determine whether or not to update:
-                # - If the site_updated_at field is changing from None to a timestamp, we update.
-                # - If the site_updated_at field is changing from a timestamp to a newer timestamp, we also update.
-                where=(
-                    (
-                        (Article.site_updated_at == None)  # type: ignore  # noqa: E711
-                        & (statement_write_articles.excluded.site_updated_at != None)  # noqa: E711
-                    )
-                    | (
-                        (Article.site_updated_at != None)  # type: ignore  # noqa: E711
-                        & (statement_write_articles.excluded.site_updated_at != None)  # noqa: E711
-                        & (Article.site_updated_at < statement_write_articles.excluded.site_updated_at)
-                    )
-                ),
+                # Bypass the condition if we're forcing an update
+                where=condition_upsert_articles if self.force_update_despite_latest else None,
             ).returning(Article.page_id)
             result_write_articles = session.scalars(statement_write_articles).unique().all()
             session.commit()

--- a/article_rec_training_job/components/page_writers/postgres.py
+++ b/article_rec_training_job/components/page_writers/postgres.py
@@ -93,7 +93,7 @@ class BaseWriter:
                     "db_updated_at": datetime.utcnow(),
                 },
                 # Bypass the condition if we're forcing an update
-                where=condition_upsert_articles if self.force_update_despite_latest else None,
+                where=None if self.force_update_despite_latest else condition_upsert_articles,
             ).returning(Article.page_id)
             result_write_articles = session.scalars(statement_write_articles).unique().all()
             session.commit()

--- a/configs/example.yaml
+++ b/configs/example.yaml
@@ -21,6 +21,7 @@ components:
     - type: postgres_base
       params:
         env_db_url: POSTGRES_DB_URL # Environment variable name containing the database URL
+        force_update_despite_latest: false # If true, update pages even if they are already up to date (useful for backfilling post-DB changes)
 
 tasks:
   - type: update_pages

--- a/tests/integration/components/page_writers/test_postgres.py
+++ b/tests/integration/components/page_writers/test_postgres.py
@@ -49,7 +49,7 @@ def pages() -> list[Page]:
 
 
 def test_base_writer_write(refresh_tables, sa_session_factory_postgres, psycopg2_adapt_unknown_types, pages):
-    writer = BaseWriter(sa_session_factory=sa_session_factory_postgres)
+    writer = BaseWriter(sa_session_factory=sa_session_factory_postgres, force_update_despite_latest=False)
     metrics = writer.write(pages)
 
     assert metrics.num_new_pages_written == 4
@@ -111,11 +111,11 @@ def test_base_writer_write(refresh_tables, sa_session_factory_postgres, psycopg2
 def test_base_writer_update_article_no_changes(
     refresh_tables, sa_session_factory_postgres, psycopg2_adapt_unknown_types, pages
 ):
-    writer = BaseWriter(sa_session_factory=sa_session_factory_postgres)
+    writer = BaseWriter(sa_session_factory=sa_session_factory_postgres, force_update_despite_latest=False)
     writer.write(pages)
 
     # Now, update article 1 with no changes
-    writer = BaseWriter(sa_session_factory=sa_session_factory_postgres)
+    writer = BaseWriter(sa_session_factory=sa_session_factory_postgres, force_update_despite_latest=False)
     metrics = writer.write([pages[1]])
 
     assert metrics.num_new_pages_written == 0
@@ -141,7 +141,7 @@ def test_base_writer_update_article_no_changes(
 def test_base_writer_update_article_no_db_updated_timestamp(
     refresh_tables, sa_session_factory_postgres, psycopg2_adapt_unknown_types, pages
 ):
-    writer = BaseWriter(sa_session_factory=sa_session_factory_postgres)
+    writer = BaseWriter(sa_session_factory=sa_session_factory_postgres, force_update_despite_latest=False)
     writer.write(pages)
 
     # Now, update article 1
@@ -160,7 +160,7 @@ def test_base_writer_update_article_no_db_updated_timestamp(
             is_in_house_content=pages[1].article.is_in_house_content,
         ),
     )
-    writer = BaseWriter(sa_session_factory=sa_session_factory_postgres)
+    writer = BaseWriter(sa_session_factory=sa_session_factory_postgres, force_update_despite_latest=False)
     metrics = writer.write([page_to_update])
 
     assert metrics.num_new_pages_written == 0
@@ -186,7 +186,7 @@ def test_base_writer_update_article_no_db_updated_timestamp(
 def test_base_writer_update_article_smaller_db_updated_timestamp(
     refresh_tables, sa_session_factory_postgres, psycopg2_adapt_unknown_types, pages
 ):
-    writer = BaseWriter(sa_session_factory=sa_session_factory_postgres)
+    writer = BaseWriter(sa_session_factory=sa_session_factory_postgres, force_update_despite_latest=False)
     writer.write(pages)
 
     # Now, update article 2
@@ -205,7 +205,7 @@ def test_base_writer_update_article_smaller_db_updated_timestamp(
             is_in_house_content=pages[2].article.is_in_house_content,
         ),
     )
-    writer = BaseWriter(sa_session_factory=sa_session_factory_postgres)
+    writer = BaseWriter(sa_session_factory=sa_session_factory_postgres, force_update_despite_latest=False)
     metrics = writer.write([page_to_update])
 
     assert metrics.num_new_pages_written == 0
@@ -236,7 +236,7 @@ def test_base_writer_update_page_add_article(
     and later on we find out that the page actually has an article and need
     to update it with the article metadata.
     """
-    writer = BaseWriter(sa_session_factory=sa_session_factory_postgres)
+    writer = BaseWriter(sa_session_factory=sa_session_factory_postgres, force_update_despite_latest=False)
     writer.write(pages)
 
     # Now, update page 3 by adding an article to it
@@ -254,7 +254,7 @@ def test_base_writer_update_page_add_article(
             is_in_house_content=False,
         ),
     )
-    writer = BaseWriter(sa_session_factory=sa_session_factory_postgres)
+    writer = BaseWriter(sa_session_factory=sa_session_factory_postgres, force_update_despite_latest=False)
     metrics = writer.write([page_to_update])
 
     assert metrics.num_new_pages_written == 0

--- a/tests/unit/config-example.yaml
+++ b/tests/unit/config-example.yaml
@@ -21,6 +21,7 @@ components:
     - type: postgres_base
       params:
         env_db_url: POSTGRES_DB_URL # Environment variable name containing the database URL
+        force_update_despite_latest: false # Optional, default false. If true, update pages even if they are already up to date (useful for backfilling post-DB changes)
 
 tasks:
   - type: update_pages

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -108,6 +108,7 @@ def test_create_page_writer_factory_dict(set_config_env, config, fake_postgres_d
     component = factory_postgres()
     assert isinstance(component, PostgresBasePageWriter)
     assert component.sa_session_factory.kw["bind"].url.render_as_string() == fake_postgres_db_url
+    assert component.force_update_despite_latest is False
 
 
 def test_create_update_pages_task(set_config_env, config):


### PR DESCRIPTION
- Adds an option to have the Postgres page writer bypass the timestamp-based `on_conflict_do_update` where-condition. It's useful when backfilling articles right after a database schema change.
- Adds a new test for this option.