### PR TITLE
Add user agent to HTTP request

### DIFF
--- a/app.py
+++ b/app.py
@@ -53,6 +53,10 @@ from article_rec_training_job.tasks.component_protocols import (
     TrafficBasedArticleRecommender,
 )
 
+# User agent string that must be included in every HTTP request
+# If update the version in pyproject.toml, update the version here as well
+HTTP_REQUEST_USER_AGENT = "LocalNewsLabArticleRecTrainingJob/2.0.0"
+
 
 def load_config_from_env() -> Config:
     """
@@ -96,6 +100,7 @@ def create_page_fetcher_factory_dict(config: Config) -> dict[PageFetcherType, Ca
             site_name=config.job_globals.site,
             slug_from_path_regex=config_component.params["slug_from_path_regex"],
             tag_id_republished_content=config_component.params.get("tag_id_republished_content"),
+            request_user_agent=HTTP_REQUEST_USER_AGENT,
             request_maximum_attempts=config_component.params.get("request_maximum_attempts", 10),
             request_maximum_backoff=config_component.params.get("request_maximum_backoff", 60),
             url_prefix_str=config_component.params["url_prefix"],

--- a/article_rec_training_job/components/event_fetchers/ga4.py
+++ b/article_rec_training_job/components/event_fetchers/ga4.py
@@ -184,7 +184,7 @@ class BaseFetcher:
         Transforms DataFrame of queried events to required schema.
         """
         # Convert event_timestamp int to pandas datetime
-        df[OutputSchema.event_timestamp] = pd.to_datetime(df[OutputSchema.event_timestamp], unit="ns", utc=True)
+        df[OutputSchema.event_timestamp] = pd.to_datetime(df[OutputSchema.event_timestamp], unit="us", utc=True)
 
         return df.pipe(OutputDataFrame)  # pipe to appease mypy, task will do the actual schema validation
 

--- a/article_rec_training_job/components/page_fetchers/wordpress.py
+++ b/article_rec_training_job/components/page_fetchers/wordpress.py
@@ -75,6 +75,8 @@ class BaseFetcher:
     slug_from_path_regex: str
     # WordPress ID of tag to signify in-house content
     tag_id_republished_content: int | None
+    # Request user agent string
+    request_user_agent: str
     # Maximum number of retries for a request
     request_maximum_attempts: int
     # Maximum backoff before retrying a request, in seconds
@@ -208,7 +210,14 @@ class BaseFetcher:
         # Fetch article
         logger.info(f"Requesting WordPress API for slug {slug}...")
         try:
-            response = await request(endpoint, self.request_maximum_attempts, self.request_maximum_backoff)
+            response = await request(
+                endpoint,
+                headers={
+                    "User-Agent": self.request_user_agent,
+                },
+                maximum_attempts=self.request_maximum_attempts,
+                maximum_backoff=self.request_maximum_backoff,
+            )
         except ClientResponseError as e:
             logger.warning(
                 f"Request to WordPress API for slug {slug} failed because response code indicated an error: {e}"

--- a/article_rec_training_job/components/page_fetchers/wordpress.py
+++ b/article_rec_training_job/components/page_fetchers/wordpress.py
@@ -253,9 +253,13 @@ class BaseFetcher:
                     is_in_house_content=self.tag_id_republished_content not in datum["tags"],
                 )
                 return Page(url=url, article=article)
+            # If response is an empty list
+            case []:
+                logger.warning(f"Request to WordPress API for slug {slug} successfully returned, but response is empty")
+                return page_without_article
             case _:
                 logger.warning(
-                    f"Request to WordPress API for slug {slug} successfully returned, but response is not what we want",
+                    f"Request to WordPress API for slug {slug} returned nonempty response, but response is not what we want",
                 )
                 return page_without_article
 

--- a/article_rec_training_job/shared/helpers/requests.py
+++ b/article_rec_training_job/shared/helpers/requests.py
@@ -10,7 +10,11 @@ from tenacity import (
 
 
 async def request(
-    url: HttpUrl, maximum_attempts: int, maximum_backoff: float, log_attempts: bool = False
+    url: HttpUrl,
+    headers: dict[str, str] | None,
+    maximum_attempts: int,
+    maximum_backoff: float,
+    log_attempts: bool = False,
 ) -> ClientResponse:
     """
     Performs an HTTP GET request to the given URL with random-exponential
@@ -29,7 +33,7 @@ async def request(
             before=log_attempt,
         ):
             with attempt:
-                async with session.get(str(url), raise_for_status=True) as response:
+                async with session.get(str(url), headers=headers, raise_for_status=True) as response:
                     # Need this to avoid the "ConnectionClosed" error
                     await response.read()
 

--- a/article_rec_training_job/shared/types/event_fetchers.py
+++ b/article_rec_training_job/shared/types/event_fetchers.py
@@ -13,7 +13,7 @@ class OutputSchema(pa.DataFrameModel):
     which is useful for pandas DataFrame operations involving columns.
     """
 
-    event_timestamp: Series[Annotated[DatetimeTZDtype, "ns", "utc"]]
+    event_timestamp: Series[Annotated[DatetimeTZDtype, "us", "utc"]]
     event_name: str
     user_id: str
     engagement_time_msec: int = pa.Field(nullable=True)

--- a/article_rec_training_job/tasks/component_protocols.py
+++ b/article_rec_training_job/tasks/component_protocols.py
@@ -35,6 +35,7 @@ class EventFetcher(Protocol):
 
 @runtime_checkable
 class PageFetcher(Protocol):
+    request_user_agent: str
     request_maximum_attempts: int
     request_maximum_backoff: float
 

--- a/tests/integration/components/article_recommenders/traffic_based/conftest.py
+++ b/tests/integration/components/article_recommenders/traffic_based/conftest.py
@@ -164,6 +164,7 @@ def events(url_1, url_2, url_3, url_4, user_id_1, user_id_2) -> EventsDataFrame:
         ],
     )
 
+    df[EventsSchema.event_timestamp] = df[EventsSchema.event_timestamp].astype("datetime64[us, UTC]")
     df[EventsSchema.engagement_time_msec] = df[EventsSchema.engagement_time_msec].astype(Int64Dtype())
     df[EventsSchema.page_url] = df[EventsSchema.page_url].apply(str)
     return df

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -115,6 +115,7 @@ def test_create_page_fetcher_factory_dict(config):
     assert component.slug_from_path_regex == r"^/20\d{2}/(0[1-9]|1[012])/(?P<slug>[a-zA-Z\d\-%]+)/$"
     assert component.language_from_path_regex[Language.SPANISH] == r"^/es/.*/$"
     assert component.tag_id_republished_content == 42
+    assert component.request_user_agent == "LocalNewsLabArticleRecTrainingJob/2.0.0"
     assert component.request_maximum_attempts == 10
     assert component.request_maximum_backoff == 60
     assert component.url_prefix_str == "https://example.com"


### PR DESCRIPTION
A user agent is required to have Dallas Free Press's WordPress API return successfully. Plus it's just good practice.